### PR TITLE
Fixes deletion of namespace defaulted resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder-base                             #############
-FROM golang:1.12.7 AS builder-base
+FROM golang:1.12.8 AS builder-base
 
 WORKDIR /go/src/github.com/gardener/gardener-resource-manager
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ revendor:
 .PHONY: start
 start:
 	@go run \
+	    -mod=vendor \
 		-ldflags $(LD_FLAGS) \
 		./cmd/gardener-resource-manager \
 	  --leader-election=false \

--- a/example/20-managedresource.yaml
+++ b/example/20-managedresource.yaml
@@ -5,19 +5,19 @@ metadata:
   name: managedresource-example1
   namespace: default
 type: Opaque
-data:
-  objects.yaml: YXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IHRlc3QtMTIzNAogIG5hbWVzcGFjZTogZGVmYXVsdAotLS0KYXBpVmVyc2lvbjogdjEKa2luZDogQ29uZmlnTWFwCm1ldGFkYXRhOgogIG5hbWU6IHRlc3QtNTY3OAogIG5hbWVzcGFjZTogZGVmYXVsdAo=
-    # apiVersion: v1
-    # kind: ConfigMap
-    # metadata:
-    #   name: test-1234
-    #   namespace: default
-    # ---
-    # apiVersion: v1
-    # kind: ConfigMap
-    # metadata:
-    #   name: test-5678
-    #   namespace: default
+stringData:
+  objects.yaml: |
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-1234
+      namespace: default
+    ---
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: test-5678
+      namespace: default
 ---
 apiVersion: v1
 kind: Secret
@@ -25,29 +25,27 @@ metadata:
   name: managedresource-example2
   namespace: default
 type: Opaque
-data:
-  other-objects.yaml: YXBpVmVyc2lvbjogYXBwcy92MSAjIGZvciB2ZXJzaW9ucyBiZWZvcmUgMS45LjAgdXNlIGFwcHMvdjFiZXRhMgpraW5kOiBEZXBsb3ltZW50Cm1ldGFkYXRhOgogIG5hbWU6IG5naW54LWRlcGxveW1lbnQKICBuYW1lc3BhY2U6IGRlZmF1bHQKc3BlYzoKICBzZWxlY3RvcjoKICAgIG1hdGNoTGFiZWxzOgogICAgICBhcHA6IG5naW54CiAgcmVwbGljYXM6IDIgIyB0ZWxscyBkZXBsb3ltZW50IHRvIHJ1biAyIHBvZHMgbWF0Y2hpbmcgdGhlIHRlbXBsYXRlCiAgdGVtcGxhdGU6CiAgICBtZXRhZGF0YToKICAgICAgbGFiZWxzOgogICAgICAgIGFwcDogbmdpbngKICAgIHNwZWM6CiAgICAgIGNvbnRhaW5lcnM6CiAgICAgIC0gbmFtZTogbmdpbngKICAgICAgICBpbWFnZTogbmdpbng6MS43LjkKICAgICAgICBwb3J0czoKICAgICAgICAtIGNvbnRhaW5lclBvcnQ6IDgwCg==
-    # apiVersion: apps/v1
-    # kind: Deployment
-    # metadata:
-    #   name: nginx-deployment
-    #   namespace: default
-    # spec:
-    #   selector:
-    #     matchLabels:
-    #       app: nginx
-    #   replicas: 2 # tells deployment to run 2 pods matching the template
-    #   template:
-    #     metadata:
-    #       labels:
-    #         app: nginx
-    #     spec:
-    #       containers:
-    #       - name: nginx
-    #         image: nginx:1.7.9
-    #         ports:
-    #         - containerPort: 80
-
+stringData:
+  other-objects.yaml: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: nginx-deployment
+    spec:
+      selector:
+        matchLabels:
+          app: nginx
+      replicas: 2 # tells deployment to run 2 pods matching the template
+      template:
+        metadata:
+          labels:
+            app: nginx
+        spec:
+          containers:
+          - name: nginx
+            image: nginx:1.7.9
+            ports:
+            - containerPort: 80
 ---
 apiVersion: resources.gardener.cloud/v1alpha1
 kind: ManagedResource

--- a/pkg/controller/managedresources/controller.go
+++ b/pkg/controller/managedresources/controller.go
@@ -134,9 +134,14 @@ func (r *reconciler) reconcile(mr *resourcesv1alpha1.ManagedResource, log logr.L
 					continue
 				}
 
+				obj := &unstructured.Unstructured{Object: decodedObj}
+				if obj.GetKind() != "Namespace" && obj.GetNamespace() == "" {
+					obj.SetNamespace(metav1.NamespaceDefault)
+				}
+
 				var (
 					newObj = object{
-						obj:                       &unstructured.Unstructured{Object: decodedObj},
+						obj:                       obj,
 						forceOverwriteLabels:      forceOverwriteLabels,
 						forceOverwriteAnnotations: forceOverwriteAnnotations,
 					}
@@ -225,10 +230,6 @@ func (r *reconciler) applyNewResources(newResourcesObjects []object, labelsToInj
 
 		go func(obj object) {
 			defer wg.Done()
-
-			if obj.obj.GetKind() != "Namespace" && obj.obj.GetNamespace() == "" {
-				obj.obj.SetNamespace(metav1.NamespaceDefault)
-			}
 
 			var (
 				current  = obj.obj.DeepCopy()

--- a/pkg/controller/managedresources/filter_test.go
+++ b/pkg/controller/managedresources/filter_test.go
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package managedresources_test
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener-resource-manager/pkg/controller/managedresources"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	. "github.com/onsi/ginkgo/extensions/table"
+)
+
+var _ = Describe("ClassFilter", func() {
+	var (
+		classOld     *string = nil
+		finalizerOld         = managedresources.FinalizerName
+
+		classNew     = "new"
+		finalizerNew = fmt.Sprintf("%s-%s", managedresources.FinalizerName, classNew)
+
+		mrOldClass = &v1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Finalizers: []string{finalizerOld},
+			},
+			Spec: v1alpha1.ManagedResourceSpec{
+				Class: classOld,
+			},
+		}
+
+		mrNewClassOldFinalizer = &v1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Finalizers: []string{finalizerOld},
+			},
+			Spec: v1alpha1.ManagedResourceSpec{
+				Class: &classNew,
+			},
+		}
+
+		mrNewClass = &v1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Finalizers: []string{finalizerNew},
+			},
+			Spec: v1alpha1.ManagedResourceSpec{
+				Class: &classNew,
+			},
+		}
+	)
+
+	DescribeTable("Active",
+		func(mr *v1alpha1.ManagedResource, class string, action, responsible bool) {
+			filter := managedresources.NewClassFilter(class)
+
+			act, resp := filter.Active(mr)
+			Expect(act).To(Equal(action))
+			Expect(resp).To(Equal(responsible))
+		},
+		Entry("is responsible and take action", mrOldClass, "", true, true),
+		Entry("is not responsible and take action", mrNewClassOldFinalizer, "", true, false),
+		Entry("is responsible and don't take action", mrNewClassOldFinalizer, classNew, false, true),
+		Entry("is not responsible and don't take action", mrNewClass, "", false, false),
+	)
+
+	DescribeTable("Generic",
+		func(mr *v1alpha1.ManagedResource, class string, expectation bool) {
+			filter := managedresources.NewClassFilter(class)
+
+			result := filter.Generic(event.GenericEvent{
+				Object: mr,
+			})
+			Expect(result).To(Equal(expectation))
+		},
+		Entry("Generic event true", mrOldClass, "", true),
+		Entry("Generic event true", mrNewClassOldFinalizer, "", true),
+		Entry("Generic event true", mrNewClassOldFinalizer, classNew, true),
+		Entry("Generic event false", mrNewClass, "", false),
+	)
+
+	DescribeTable("Create",
+		func(mr *v1alpha1.ManagedResource, class string, expectation bool) {
+			filter := managedresources.NewClassFilter(class)
+
+			result := filter.Create(event.CreateEvent{
+				Object: mr,
+			})
+			Expect(result).To(Equal(expectation))
+		},
+		Entry("Create event true", mrOldClass, "", true),
+		Entry("Create event true", mrNewClassOldFinalizer, "", true),
+		Entry("Create event true", mrNewClassOldFinalizer, classNew, true),
+		Entry("Create event false", mrNewClass, "", false),
+	)
+
+	DescribeTable("Delete",
+		func(mr *v1alpha1.ManagedResource, class string, expectation bool) {
+			filter := managedresources.NewClassFilter(class)
+
+			result := filter.Delete(event.DeleteEvent{
+				Object: mr,
+			})
+			Expect(result).To(Equal(expectation))
+		},
+		Entry("Delete event true", mrOldClass, "", true),
+		Entry("Delete event true", mrNewClassOldFinalizer, "", true),
+		Entry("Delete event true", mrNewClassOldFinalizer, classNew, true),
+		Entry("Delete event false", mrNewClass, "", false),
+	)
+
+	DescribeTable("Update",
+		func(mr *v1alpha1.ManagedResource, class string, expectation bool) {
+			filter := managedresources.NewClassFilter(class)
+
+			result := filter.Update(event.UpdateEvent{
+				ObjectNew: mr,
+			})
+			Expect(result).To(Equal(expectation))
+		},
+		Entry("Update event true", mrOldClass, "", true),
+		Entry("Update event true", mrNewClassOldFinalizer, "", true),
+		Entry("Update event true", mrNewClassOldFinalizer, classNew, true),
+		Entry("Update event false", mrNewClass, "", false),
+	)
+})

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,98 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, false)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, true)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, pending bool, focused bool) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	if pending {
+		ginkgo.PDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else if focused {
+		ginkgo.FDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else {
+		ginkgo.Describe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	}
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,81 @@
+package table
+
+import (
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description string
+	Parameters  []interface{}
+	Pending     bool
+	Focused     bool
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	if t.Pending {
+		ginkgo.PIt(t.Description)
+		return
+	}
+
+	values := []reflect.Value{}
+	for i, param := range t.Parameters {
+		var value reflect.Value
+
+		if param == nil {
+			inType := itBody.Type().In(i)
+			value = reflect.Zero(inType)
+		} else {
+			value = reflect.ValueOf(param)
+		}
+
+		values = append(values, value)
+	}
+
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		ginkgo.FIt(t.Description, body)
+	} else {
+		ginkgo.It(t.Description, body)
+	}
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, false}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, true}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -85,6 +85,7 @@ github.com/onsi/ginkgo/ginkgo/watch
 github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/types
 github.com/onsi/ginkgo
+github.com/onsi/ginkgo/extensions/table
 github.com/onsi/ginkgo/internal/remote
 github.com/onsi/ginkgo/reporters/stenographer
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves the `namespace` defaulting for resources which do not specify any. This allows the `Gardener-Resource-Manager` to delete the resource adequately.

**Which issue(s) this PR fixes**:
Fixes #7

**Special notes for your reviewer**:
The PR also includes:
- Tests for `class` filter
- Upgrade to Golang `1.12.8`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator
-->
```improvement operator
Fixes an issue which left resources in the `target` cluster even though they were supposed to be deleted through a change or removal of the `ManagedResource`.
```
