### PR TITLE
Support for version and api group migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.kube-secrets
 /tmp
+/local
 /dev
 **/dev
 

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -63,6 +63,9 @@ type ManagedResourceSpec struct {
 	// Defaults to false.
 	// +optional
 	KeepObjects *bool `json:"keepObjects,omitempty"`
+	// Equivalences specifies possible group/kind equivalences for objects.
+	// +optional
+	Equivalences [][]metav1.GroupKind `json:"equivalences,omitempty"`
 }
 
 // ManagedResourceStatus is the status of a managed resource.

--- a/pkg/apis/resources/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/resources/v1alpha1/zz_generated.deepcopy.go
@@ -19,6 +19,7 @@ package v1alpha1
 
 import (
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -135,6 +136,17 @@ func (in *ManagedResourceSpec) DeepCopyInto(out *ManagedResourceSpec) {
 		in, out := &in.KeepObjects, &out.KeepObjects
 		*out = new(bool)
 		**out = **in
+	}
+	if in.Equivalences != nil {
+		in, out := &in.Equivalences, &out.Equivalences
+		*out = make([][]metav1.GroupKind, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = make([]metav1.GroupKind, len(*in))
+				copy(*out, *in)
+			}
+		}
 	}
 	return
 }

--- a/pkg/controller/managedresources/equivalence_test.go
+++ b/pkg/controller/managedresources/equivalence_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedresources
+
+import (
+	"github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
+	schema "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Resource Equivalences", func() {
+
+	Describe("Setup", func() {
+		It("single set ", func() {
+			equis := equivalences{
+				[]schema.GroupKind{
+					schema.GroupKind{"groupA", "kindA"},
+					schema.GroupKind{"groupB", "kindB"},
+					schema.GroupKind{"groupC", "kindC"},
+				},
+			}
+
+			set := GroupKindSet{}.Insert(equis[0]...)
+			index := NewObjectIndex(nil, equis)
+
+			Expect(index.GetEquivalencesFor(equis[0][0])).To(Equal(set))
+			Expect(index.GetEquivalencesFor(equis[0][1])).To(Equal(set))
+			Expect(index.GetEquivalencesFor(equis[0][2])).To(Equal(set))
+		})
+		It("multiple sets", func() {
+			equis := equivalences{
+				[]schema.GroupKind{
+					schema.GroupKind{"groupA", "kindA"},
+					schema.GroupKind{"groupB", "kindB"},
+					schema.GroupKind{"groupC", "kindC"},
+				},
+				[]schema.GroupKind{
+					schema.GroupKind{"groupA1", "kindA1"},
+					schema.GroupKind{"groupB1", "kindB1"},
+					schema.GroupKind{"groupC1", "kindC1"},
+				},
+			}
+
+			set0 := GroupKindSet{}.Insert(equis[0]...)
+			set1 := GroupKindSet{}.Insert(equis[1]...)
+			index := NewObjectIndex(nil, equis)
+
+			Expect(index.GetEquivalencesFor(equis[0][0])).To(Equal(set0))
+			Expect(index.GetEquivalencesFor(equis[0][1])).To(Equal(set0))
+			Expect(index.GetEquivalencesFor(equis[0][2])).To(Equal(set0))
+
+			Expect(index.GetEquivalencesFor(equis[1][0])).To(Equal(set1))
+			Expect(index.GetEquivalencesFor(equis[1][1])).To(Equal(set1))
+			Expect(index.GetEquivalencesFor(equis[1][2])).To(Equal(set1))
+		})
+
+		It("mixed sets", func() {
+			equis := equivalences{
+				[]schema.GroupKind{
+					schema.GroupKind{"groupA", "kindA"},
+					schema.GroupKind{"groupB", "kindB"},
+				},
+				[]schema.GroupKind{
+					schema.GroupKind{"groupB", "kindB"},
+					schema.GroupKind{"groupC", "kindC"},
+				},
+			}
+
+			set := GroupKindSet{}.Insert(equis[0]...).Insert(equis[1]...)
+			index := NewObjectIndex(nil, equis)
+
+			Expect(index.GetEquivalencesFor(equis[0][0])).To(Equal(set))
+			Expect(index.GetEquivalencesFor(equis[0][1])).To(Equal(set))
+
+			Expect(index.GetEquivalencesFor(equis[1][0])).To(Equal(set))
+			Expect(index.GetEquivalencesFor(equis[1][1])).To(Equal(set))
+		})
+	})
+	Describe("Lookup", func() {
+		It("single", func() {
+			equis := equivalences{
+				[]schema.GroupKind{
+					schema.GroupKind{"groupA", "kindA"},
+					schema.GroupKind{"groupB", "kindB"},
+					schema.GroupKind{"groupC", "kindC"},
+				},
+			}
+
+			refold := v1alpha1.ObjectReference{
+				ObjectReference: v1.ObjectReference{Name: "name", Namespace: "ns", Kind: "kindA", APIVersion: "groupA/v2"},
+			}
+
+			refunused := v1alpha1.ObjectReference{
+				ObjectReference: v1.ObjectReference{Name: "foo", Namespace: "bar", Kind: "kind", APIVersion: "group/v1"},
+			}
+			old := []v1alpha1.ObjectReference{
+				refold,
+				refunused,
+			}
+
+			index := NewObjectIndex(old, equis)
+
+			refnew := v1alpha1.ObjectReference{
+				ObjectReference: v1.ObjectReference{Name: "name", Namespace: "ns", Kind: "kindB", APIVersion: "groupB/v1"},
+			}
+
+			found, _ := index.Lookup(refnew)
+			Expect(found).To(Equal(refold))
+			Expect(index.Found(refold)).To(BeTrue())
+			Expect(index.Found(refunused)).To(BeFalse())
+		})
+	})
+})

--- a/pkg/controller/managedresources/equivalences.go
+++ b/pkg/controller/managedresources/equivalences.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedresources
+
+import (
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type equivalences [][]metav1.GroupKind
+
+var defaultEquivalences = equivalences{
+	EquiSetForKind("Deployment", "extensions", "apps"),
+	EquiSetForKind("DaemonSet", "extensions", "apps"),
+	EquiSetForKind("ReplicaSet", "extensions", "apps"),
+	EquiSetForKind("StatefulSet", "extensions", "apps"),
+	EquiSetForKind("Ingress", "extensions", "networking.k8s.io"),
+	EquiSetForKind("NetworkPolicy", "extensions", "networking.k8s.io"),
+	EquiSetForKind("PodSecurityPolicy", "extensions", "policy"),
+}
+
+type GroupKindSet map[metav1.GroupKind]struct{}
+
+func (s GroupKindSet) Insert(gks ...metav1.GroupKind) GroupKindSet {
+	for _, gk := range gks {
+		s[gk] = struct{}{}
+	}
+	return s
+
+}
+func (s GroupKindSet) Delete(gks ...metav1.GroupKind) GroupKindSet {
+	for _, gk := range gks {
+		delete(s, gk)
+	}
+	return s
+}
+
+type ObjectIndex struct {
+	index        map[string]resourcesv1alpha1.ObjectReference
+	found        sets.String
+	equivalences map[metav1.GroupKind]GroupKindSet
+}
+
+func NewObjectIndex(resources []resourcesv1alpha1.ObjectReference, equis equivalences) *ObjectIndex {
+	index := &ObjectIndex{
+		make(map[string]resourcesv1alpha1.ObjectReference, len(resources)),
+		sets.String{},
+		map[metav1.GroupKind]GroupKindSet{},
+	}
+
+	for _, r := range resources {
+		index.index[objectKeyByReference(r)] = r
+	}
+	index.addEquivalences(defaultEquivalences)
+	index.addEquivalences(equis)
+	return index
+}
+
+func (i *ObjectIndex) Objects() map[string]resourcesv1alpha1.ObjectReference {
+	return i.index
+}
+
+func (i *ObjectIndex) addEquivalences(equis equivalences) {
+	for _, equi := range equis {
+		var m GroupKindSet
+		for _, e := range equi {
+			if f, ok := i.equivalences[e]; ok {
+				m = f
+				break
+			}
+		}
+		if m == nil {
+			m = map[metav1.GroupKind]struct{}{}
+		}
+		for _, e := range equi {
+			m.Insert(e)
+			i.equivalences[e] = m
+		}
+	}
+}
+
+func (i ObjectIndex) GetEquivalencesFor(gk metav1.GroupKind) GroupKindSet {
+	return i.equivalences[gk]
+}
+
+func (i ObjectIndex) Found(ref resourcesv1alpha1.ObjectReference) bool {
+	return i.found.Has(objectKeyByReference(ref))
+}
+
+func (i ObjectIndex) Lookup(ref resourcesv1alpha1.ObjectReference) (resourcesv1alpha1.ObjectReference, bool) {
+	key := objectKeyByReference(ref)
+	if found, ok := i.index[key]; ok {
+		i.found.Insert(key)
+		return found, ok
+	}
+	gk := metav1.GroupKind{ref.GroupVersionKind().Group, ref.Kind}
+	equis, ok := i.equivalences[gk]
+	if ok {
+		for e := range equis {
+			key = objectKey(e.Group, e.Kind, ref.Namespace, ref.Name)
+			if found, ok := i.index[key]; ok {
+				i.found.Insert(key)
+				return found, ok
+			}
+		}
+	}
+	return resourcesv1alpha1.ObjectReference{}, false
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func EquiSetForKind(kind string, groups ...string) []metav1.GroupKind {
+	r := []metav1.GroupKind{}
+
+	for _, g := range groups {
+		r = append(r, metav1.GroupKind{g, kind})
+	}
+	return r
+}

--- a/pkg/controller/managedresources/health/health_controller.go
+++ b/pkg/controller/managedresources/health/health_controller.go
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package health
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
Old objects should not be deletes if new ones have a new version or an equivalent API Group.
Therefore:
- the key to lookup old and new objects must not contain the version of an API group
- looking for old and/or new objects should take a api group equivalences into account. This is supported by the possibility to add default equivalences into the controller code and/or to enrich a manages resource object by equivalences that should be observed during deployment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The resource manager now observes version updates for objects and supports configurable api group migrations.
```
