### PR TITLE
Allow ignoring resources by annotation

### DIFF
--- a/docs/concepts/managed-resource.md
+++ b/docs/concepts/managed-resource.md
@@ -41,5 +41,15 @@ The following section describes a healthy ManagedResource:
     "lastUpdateTime": "2019-09-09T11:31:21Z",
     "lastTransitionTime": "2019-09-09T11:31:21Z"
   }
-]   
+]  
 ```
+
+## Ignoring Updates 
+
+In some cases it is not desirable to update or re-apply some of the cluster components (for example, if customization is required or needs to be applied by the end-user). 
+For these resources, the annotation "resources.gardener.cloud/ignore" needs to be set to "true" or a truthy value (Truthy values are "1", "t", "T", "true", "TRUE", "True") in the corresponding managed resource secrets, 
+this can be done from the components that create the managed resource secrets, for example Gardener extensions or Gardener. Once this is done, the resource will be initially created and later ignored during reconciliation.
+
+
+
+

--- a/example/20-managedresource.yaml
+++ b/example/20-managedresource.yaml
@@ -12,6 +12,8 @@ stringData:
     metadata:
       name: test-1234
       namespace: default
+      annotations:
+        resources.gardener.cloud/ignore: "true"
     ---
     apiVersion: v1
     kind: ConfigMap

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -19,6 +19,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ResourceManagerIgnoreAnnotation is an annotation that dictates whether a resources should be ignored during reconciliation.
+const ResourceManagerIgnoreAnnotation = "resources.gardener.cloud/ignore"
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ManagedResource describes a list of managed resources.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an annotation to allow gardener-resource-manager to ignore specific resources. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener-resource-manager now supports ignoring resources annotated with `resources.gardener.cloud/ignore: "true"`. This is to allow customisation of resources if required.
```
