### PR TITLE
Do not overwrite HealthCheckNodePort with 0 for service

### DIFF
--- a/pkg/controller/managedresources/merger.go
+++ b/pkg/controller/managedresources/merger.go
@@ -104,9 +104,9 @@ func mergeService(scheme *runtime.Scheme, oldObj, newObj runtime.Object) error {
 		return err
 	}
 
-	// We do not want to overwrite a Service's `.spec.clusterIP' or '.spec.ports[*].nodePort' values.
+	// We do not want to overwrite a Service's `.spec.clusterIP', `.spec.healthCheckNodePort` and '.spec.ports[*].nodePort' values.
 	newService.Spec.ClusterIP = oldService.Spec.ClusterIP
-
+	newService.Spec.HealthCheckNodePort = oldService.Spec.HealthCheckNodePort
 	var ports []corev1.ServicePort
 	for _, np := range newService.Spec.Ports {
 		p := np


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, the resource manager always set HealthCheckNodePort with 0 when updating a Service. This is not correct when externalTrafficPolicy is Local. In this PR, we just do not overwite HealthCheckNodePort.
**Which issue(s) this PR fixes**:
Fixes #28

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Gardener resource manager can now handle Services whose externalTrafficPolicy equals Local correctly.
```
