### PR TITLE
`CheckManagedResource` func includes health reason

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -36,7 +36,7 @@ func CheckManagedResource(mr *v1alpha1.ManagedResource) error {
 	appliedCondition := false
 	for _, cond := range status.Conditions {
 		if cond.Status != v1alpha1.ConditionTrue {
-			return fmt.Errorf("condition %s of managed resource %s/%s is %s - waiting to become %s", cond.Type, mr.GetNamespace(), mr.GetName(), cond.Status, v1alpha1.ConditionTrue)
+			return fmt.Errorf("condition %s of managed resource %s/%s is %s: %s", cond.Type, mr.GetNamespace(), mr.GetName(), cond.Status, cond.Message)
 		}
 		if cond.Type == v1alpha1.ResourcesApplied {
 			appliedCondition = true


### PR DESCRIPTION
**What this PR does / why we need it**:
`CheckManagedResource` func includes health reason

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
