### PR TITLE
Split health helper functions to test conditions separately

### DIFF
--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -308,6 +308,18 @@ var _ = Describe("health", func() {
 					},
 				},
 			}, HaveOccurred()),
+			Entry("no healthy condition", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions: []v1alpha1.ManagedResourceCondition{
+						{
+							Type:   v1alpha1.ResourcesApplied,
+							Status: v1alpha1.ConditionTrue,
+						},
+					},
+				},
+			}, HaveOccurred()),
 			Entry("no conditions", v1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{Generation: 1},
 				Status: v1alpha1.ManagedResourceStatus{
@@ -316,6 +328,110 @@ var _ = Describe("health", func() {
 			}, HaveOccurred()),
 			Entry("outdated generation", v1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: v1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+				},
+			}, HaveOccurred()),
+			Entry("no status", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+			}, HaveOccurred()),
+		)
+	})
+
+	Context("CheckManagedResourceApplied", func() {
+		DescribeTable("managedresource",
+			func(mr v1alpha1.ManagedResource, matcher types.GomegaMatcher) {
+				err := health.CheckManagedResourceApplied(&mr)
+				Expect(err).To(matcher)
+			},
+			Entry("applied condition not true", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions: []v1alpha1.ManagedResourceCondition{
+						{
+							Type:   v1alpha1.ResourcesApplied,
+							Status: v1alpha1.ConditionFalse,
+						},
+					},
+				},
+			}, HaveOccurred()),
+			Entry("condition true", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions: []v1alpha1.ManagedResourceCondition{
+						{
+							Type:   v1alpha1.ResourcesApplied,
+							Status: v1alpha1.ConditionTrue,
+						},
+					},
+				},
+			}, Not(HaveOccurred())),
+			Entry("no applied condition", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions:         []v1alpha1.ManagedResourceCondition{},
+				},
+			}, HaveOccurred()),
+			Entry("no conditions", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+				},
+			}, HaveOccurred()),
+			Entry("outdated generation", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: v1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+				},
+			}, HaveOccurred()),
+			Entry("no status", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+			}, HaveOccurred()),
+		)
+	})
+
+	Context("CheckManagedResourceHealthy", func() {
+		DescribeTable("managedresource",
+			func(mr v1alpha1.ManagedResource, matcher types.GomegaMatcher) {
+				err := health.CheckManagedResourceHealthy(&mr)
+				Expect(err).To(matcher)
+			},
+			Entry("healthy condition not true", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions: []v1alpha1.ManagedResourceCondition{
+						{
+							Type:   v1alpha1.ResourcesHealthy,
+							Status: v1alpha1.ConditionFalse,
+						},
+					},
+				},
+			}, HaveOccurred()),
+			Entry("condition true", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions: []v1alpha1.ManagedResourceCondition{
+						{
+							Type:   v1alpha1.ResourcesHealthy,
+							Status: v1alpha1.ConditionTrue,
+						},
+					},
+				},
+			}, Not(HaveOccurred())),
+			Entry("no healthy condition", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: v1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions:         []v1alpha1.ManagedResourceCondition{},
+				},
+			}, HaveOccurred()),
+			Entry("no conditions", v1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
 				Status: v1alpha1.ManagedResourceStatus{
 					ObservedGeneration: 1,
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR splits the helper function `CheckManagedResource` into two separate functions which allow to either test for the `Applied` condition (and observedGeneration) or the `Healthy` condition.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Prereq for [gardener#1876](https://github.com/gardener/gardener/pull/1876)

`CheckManagedResource` now errors if there is no `Healthy` condition, which wasn't the case before.
But I guess, this shouldn't be problematic, right?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
