### PR TITLE
Allow Service .spec.externalTrafficPolicy to be set to Local by MutatingWebhookConfiguration

### DIFF
--- a/pkg/controller/managedresources/merger.go
+++ b/pkg/controller/managedresources/merger.go
@@ -172,7 +172,6 @@ func mergeService(scheme *runtime.Scheme, oldObj, newObj runtime.Object) error {
 
 	if oldService.Spec.Type == corev1.ServiceTypeLoadBalancer &&
 		newService.Spec.Type == corev1.ServiceTypeLoadBalancer &&
-		newService.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal &&
 		oldService.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal &&
 		newService.Spec.HealthCheckNodePort == 0 {
 		newService.Spec.HealthCheckNodePort = oldService.Spec.HealthCheckNodePort


### PR DESCRIPTION
**What this PR does / why we need it**:
We have cases in which we set the `.spec.externalTrafficPolicy` to `Local` via `MutatingWebhookConfiguration`. In such cases we do not want to overwrite the `.spec.healthCheckNodePort` to `0` as the field cannot be changed and the update will fail.

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/gardener/issues/2048

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing a Service apply to fail when a `MutatingWebhookConfiguration` sets `.spec.externalTrafficPolicy` to `Local` is now fixed.
```
