### PR TITLE
Protect referenced secrets with finalizer

### DIFF
--- a/pkg/controller/managedresources/controller.go
+++ b/pkg/controller/managedresources/controller.go
@@ -145,6 +145,11 @@ func (r *Reconciler) reconcile(mr *resourcesv1alpha1.ManagedResource, log logr.L
 			return reconcile.Result{}, err
 		}
 
+		if err := utils.EnsureFinalizer(r.ctx, r.client, r.class.FinalizerName(), secret); err != nil {
+			log.Error(err, "Failed to ensure finalizer on secret %q referenced by managed resource", "name", ref.Name)
+			return reconcile.Result{}, err
+		}
+
 		for key, value := range secret.Data {
 			var (
 				decoder    = yaml.NewYAMLOrJSONDecoder(bytes.NewReader(value), 1024)
@@ -270,6 +275,18 @@ func (r *Reconciler) delete(mr *resourcesv1alpha1.ManagedResource, log logr.Logg
 		}
 	} else {
 		log.Info(fmt.Sprintf("Do not delete any resources of %s because .spec.keepObjects=true", mr.Name))
+	}
+
+	for _, ref := range mr.Spec.SecretRefs {
+		secret := &corev1.Secret{}
+		if err := r.client.Get(r.ctx, client.ObjectKey{Namespace: mr.Namespace, Name: ref.Name}, secret); err != nil {
+			log.Error(err, "Could not read secret", "name", secret.Name)
+			return reconcile.Result{}, err
+		}
+		if err := utils.DeleteFinalizer(r.ctx, r.client, r.class.FinalizerName(), secret); err != nil {
+			log.Error(err, "Failed to remove finalizer from secret referenced by managed resource", "name", ref.Name)
+			return reconcile.Result{}, err
+		}
 	}
 
 	if err := utils.DeleteFinalizer(r.ctx, r.client, r.class.FinalizerName(), mr); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR,  `grm` adds its finalizer to every `Secret` referenced in a `ManagedResource`.
It deletes the finalizers again, after the deletion has succeeded.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`gardener-resource-manager` now adds finalizers to Secrets referenced in `ManagedResource`s to prevent Secrets from being deleted accidentally.
```
