### PR TITLE
Fix retry apply on conflict

### DIFF
--- a/pkg/controller/managedresources/controller.go
+++ b/pkg/controller/managedresources/controller.go
@@ -323,6 +323,12 @@ func (r *Reconciler) applyNewResources(newResourcesObjects []object, labelsToInj
 						// has been merged and released.
 						r.targetRESTMapper.Reset()
 					}
+					if apierrors.IsConflict(err) {
+						r.log.Info(fmt.Sprintf("conflict during apply of object %q: %s", resource, err))
+						// return conflict error directly, so that the update will be retried
+						return err
+					}
+
 					return fmt.Errorf("error during apply of object %q: %s", resource, err)
 				}
 				return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix retry apply on conflict for managed objects, so that the controller does not run into backoff on conflict, but instead retries applying directly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed, which made `gardener-resource-manager` fail to apply all new objects, if there were conflicting changes on those objects, instead of retrying the update request.
```
