### PR TITLE
add annotation with warning for managed resources

### DIFF
--- a/pkg/controller/managedresources/controller.go
+++ b/pkg/controller/managedresources/controller.go
@@ -380,6 +380,10 @@ func (r *Reconciler) applyNewResources(newResourcesObjects []object, labelsToInj
 					}
 					// if the reconcile annotation is set to false, do nothing (ignore the resource)
 					if ignore(metadata) {
+						anns := current.GetAnnotations()
+						delete(anns, descriptionAnnotation)
+
+						current.SetAnnotations(anns)
 						return nil
 					}
 

--- a/pkg/controller/managedresources/merger_test.go
+++ b/pkg/controller/managedresources/merger_test.go
@@ -111,6 +111,31 @@ var _ = Describe("merger", func() {
 			Expect(merge(desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(BeNil())
 		})
+
+		Describe("sets warning annotation", func() {
+			AfterEach(func() {
+				Expect(current.GetAnnotations()).
+					To(HaveKeyWithValue("resources.gardener.cloud/description", descriptionAnnotationText))
+			})
+
+			It("when forceOverrideAnnotation is false", func() {
+				Expect(merge(desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+			})
+			It("when forceOverrideAnnotation is false and old annotations exist", func() {
+				desired.SetAnnotations(map[string]string{"goo": "boo"})
+				current.SetAnnotations(map[string]string{"foo": "bar"})
+				Expect(merge(desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+
+				Expect(current.GetAnnotations()).To(HaveKeyWithValue("goo", "boo"))
+				Expect(current.GetAnnotations()).To(HaveKeyWithValue("foo", "bar"))
+			})
+
+			It("when forceOverrideAnnotation is true", func() {
+				desired.SetAnnotations(map[string]string{"goo": "boo"})
+				Expect(merge(desired, current, false, nil, true, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+				Expect(current.GetAnnotations()).To(HaveKeyWithValue("goo", "boo"))
+			})
+		})
 	})
 
 	Describe("#mergeDeployment", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

it adds the following annotation to all resources managed by `resource-manager`
```yaml
metadata:
  annotations:
    resource-manager.gardener.cloud/description: |-
      DO NOT EDIT - This resource is managed by gardener-resource-manager.
      Any modifications are discarded and the resource is returned to the original state.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
All resources managed by `resource-manager` now have `resource-manager.gardener.cloud/description` annotation with `DO NOT EDIT` warning.
```
