### PR TITLE
Use cached client for apply

### DIFF
--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -23,13 +23,12 @@ import (
 	"sync"
 	"time"
 
-	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
-
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener-resource-manager/pkg/controller/managedresources"
 	"github.com/gardener/gardener-resource-manager/pkg/controller/managedresources/health"
 	logpkg "github.com/gardener/gardener-resource-manager/pkg/log"
 
+	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
@@ -167,6 +166,7 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 					mgr.GetClient(),
 					targetClient,
 					targetRESTMapper,
+					targetScheme,
 					filter,
 					syncPeriod,
 				),

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	k8s.io/api v0.0.0-20190918155943-95b840bb6a1f // kubernetes-1.16.0
 	k8s.io/apiextensions-apiserver v0.0.0-20190918161926-8f644eb6e783 // kubernetes-1.16.0
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655 // kubernetes-1.16.0
+	k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible // kubernetes-1.16.0
 	k8s.io/code-generator v0.0.0-20190912054826-cd179ad6a269 // kubernetes-1.16.0
 	k8s.io/gengo v0.0.0-20190826232639-a874a240740c // indirect

--- a/go.sum
+++ b/go.sum
@@ -475,6 +475,7 @@ k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d/go.mod h1:ccL7Eh7zubPUSh9
 k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655 h1:CS1tBQz3HOXiseWZu6ZicKX361CZLT97UFnnPx0aqBw=
 k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655/go.mod h1:nL6pwRT8NgfF8TT68DBI8uEePRt89cSvoXUVqbkWHq4=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
+k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e h1:5AX59ZgftHpbmNupSWosdtW4q/rCnF4s/0J0dEfJkAQ=
 k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e/go.mod h1:QEXezc9uKPT91dwqhSJq3GNI3B1HxFRQHiku9kmrsSA=
 k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90 h1:mLmhKUm1X+pXu0zXMEzNsOF5E2kKFGe5o6BZBIIqA6A=
 k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90/go.mod h1:J69/JveO6XESwVgG53q3Uz5OSfgsv4uxpScmmyYOOlk=

--- a/pkg/controller/managedresources/merger.go
+++ b/pkg/controller/managedresources/merger.go
@@ -36,8 +36,15 @@ func merge(desired, current *unstructured.Unstructured, forceOverwriteLabels boo
 	newObject := current
 	desired.DeepCopyInto(newObject)
 
-	newObject.SetResourceVersion(oldObject.GetResourceVersion())
-	newObject.SetFinalizers(oldObject.GetFinalizers())
+	// keep metadata information of old object to avoid unnecessary update calls
+	if oldMetadataInterface, ok := oldObject.Object["metadata"]; ok {
+		// cast to map to be able to check if metadata is empty
+		if oldMetadataMap, ok := oldMetadataInterface.(map[string]interface{}); ok {
+			if len(oldMetadataMap) > 0 {
+				newObject.Object["metadata"] = oldMetadataMap
+			}
+		}
+	}
 
 	if forceOverwriteLabels {
 		newObject.SetLabels(desired.GetLabels())
@@ -274,21 +281,36 @@ func mergeServiceAccount(scheme *runtime.Scheme, oldObj, newObj runtime.Object) 
 	return scheme.Convert(newServiceAccount, newObj, nil)
 }
 
+// mergeMapsBasedOnOldMap merges the values of the desired map into the current map.
+// It takes an optional map of old desired values and removes any keys/values from the resulting map
+// that were once desired (part of `old`) but are not desired anymore.
 func mergeMapsBasedOnOldMap(desired, current, old map[string]string) map[string]string {
 	out := map[string]string{}
+	// use current as base
+	for k, v := range current {
+		out[k] = v
+	}
+
+	// overwrite desired values
 	for k, v := range desired {
 		out[k] = v
 	}
 
-	for k, v := range current {
-		oldValue, ok := old[k]
-		desiredValue, ok2 := desired[k]
-
-		if ok && oldValue == v && (!ok2 || desiredValue != v) {
+	// check if we should remove values which were once desired but are not desired anymore
+	for k, oldValue := range old {
+		currentValue, isInCurrent := current[k]
+		if !isInCurrent || currentValue != oldValue {
+			// is not part of the current map anymore or has been changed by the enduser -> don't remove
 			continue
 		}
 
-		out[k] = v
+		if _, isDesired := desired[k]; !isDesired {
+			delete(out, k)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
 	}
 
 	return out

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -19,9 +19,11 @@ import (
 	"reflect"
 	"time"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -136,6 +138,67 @@ func finalizersAndAccessorOf(obj runtime.Object) (sets.String, metav1.Object, er
 // It retries the update with an exponential backoff.
 func TryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj runtime.Object, transform func() error) error {
 	return tryUpdate(ctx, backoff, c, obj, c.Update, transform)
+}
+
+// TypedCreateOrUpdate is like controllerutil.CreateOrUpdate, it retrieves the current state of the object from the
+// API server, applies the given mutate func and creates or updates it afterwards. In contrast to
+// controllerutil.CreateOrUpdate it tries to create a new typed object of obj's kind (using the provided scheme)
+// to make typed Get requests in order to leverage the client's cache.
+func TypedCreateOrUpdate(ctx context.Context, c client.Client, scheme *runtime.Scheme, obj *unstructured.Unstructured, mutate func() error) error {
+	key, err := client.ObjectKeyFromObject(obj)
+	if err != nil {
+		return err
+	}
+
+	// client.DelegatingReader does not use its cache for unstructured.Unstructured objects, so we
+	// create a new typed object of the object's type to use the cache for get calls before applying changes
+	var current runtime.Object
+	if typed, err := scheme.New(obj.GetObjectKind().GroupVersionKind()); err == nil {
+		current = typed
+	} else {
+		// fallback to unstructured request (type might not be registered in scheme)
+		current = obj
+	}
+
+	if err := c.Get(ctx, key, current); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		if err := mutate(); err != nil {
+			return err
+		}
+		if err := c.Create(ctx, obj); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	var existing *unstructured.Unstructured
+
+	// convert object back to unstructured for easy mutating/merging
+	if _, isUnstructured := current.(*unstructured.Unstructured); !isUnstructured {
+		u := &unstructured.Unstructured{}
+		if err := scheme.Convert(current, u, nil); err != nil {
+			return err
+		}
+		u.DeepCopyInto(obj)
+		existing = u
+	} else {
+		existing = obj.DeepCopy()
+	}
+
+	if err := mutate(); err != nil {
+		return err
+	}
+
+	if apiequality.Semantic.DeepEqual(existing, obj) {
+		return nil
+	}
+
+	if err := c.Update(ctx, obj); err != nil {
+		return err
+	}
+	return nil
 }
 
 // TryUpdateStatus tries to apply the given transformation function onto the given object, and to update its

--- a/pkg/controller/utils/utils_suite_test.go
+++ b/pkg/controller/utils/utils_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"context"
+
+	. "github.com/gardener/gardener-resource-manager/pkg/controller/utils"
+	mockclient "github.com/gardener/gardener-resource-manager/pkg/mock/controller-runtime/client"
+	. "github.com/gardener/gardener-resource-manager/pkg/test"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	autoscalerv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("utils", func() {
+
+	Describe("#TypedCreateOrUpdate", func() {
+		var (
+			ctx  context.Context
+			ctrl *gomock.Controller
+			c    *mockclient.MockClient
+			s    *runtime.Scheme
+
+			name      string
+			namespace string
+			obj       *unstructured.Unstructured
+		)
+
+		BeforeEach(func() {
+			ctx = context.TODO()
+			s = scheme.Scheme
+
+			ctrl = gomock.NewController(GinkgoT())
+			c = mockclient.NewMockClient(ctrl)
+
+			name = "foo"
+			namespace = "bar"
+
+			obj = &unstructured.Unstructured{}
+			obj.SetName(name)
+			obj.SetNamespace(namespace)
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		Context("kind registered in scheme (Deployment)", func() {
+			var (
+				deploymentGVK schema.GroupVersionKind
+
+				currentDeployment             *appsv1.Deployment
+				currentDeploymentUnstructured *unstructured.Unstructured
+			)
+
+			BeforeEach(func() {
+				deploymentGVK = appsv1.SchemeGroupVersion.WithKind("Deployment")
+				obj.SetGroupVersionKind(deploymentGVK)
+
+				currentDeployment = &appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+					Spec: appsv1.DeploymentSpec{
+						Replicas: pointer.Int32Ptr(1),
+					},
+				}
+
+				currentDeploymentUnstructured = &unstructured.Unstructured{}
+				Expect(s.Convert(currentDeployment, currentDeploymentUnstructured, nil)).To(Succeed(), "should be able to convert deployment to unstructured")
+			})
+
+			It("should make a typed get request and correctly create the object", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).
+						Return(apierrors.NewNotFound(appsv1.Resource("deployments"), name)),
+					c.EXPECT().Create(ctx, obj),
+				)
+
+				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+					Expect(obj.Object["spec"]).To(BeNil(), "obj should not be filled, as the object does not exist yet")
+					return nil
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should make a typed get request and skip update (no changes)", func() {
+				c.EXPECT().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, o runtime.Object) error {
+						deploy, ok := o.(*appsv1.Deployment)
+						Expect(ok).To(BeTrue())
+
+						currentDeployment.DeepCopyInto(deploy)
+						return nil
+					})
+
+				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+					Expect(obj).To(BeSemanticallyEqual(currentDeploymentUnstructured), "obj should be filled with the obj's current spec")
+					return nil
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should make a typed get request and correctly update the object", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).
+						DoAndReturn(func(ctx context.Context, key client.ObjectKey, o runtime.Object) error {
+							deploy, ok := o.(*appsv1.Deployment)
+							Expect(ok).To(BeTrue())
+
+							currentDeployment.DeepCopyInto(deploy)
+							return nil
+						}),
+					c.EXPECT().Update(ctx, obj),
+				)
+
+				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+					Expect(obj).To(BeSemanticallyEqual(currentDeploymentUnstructured), "obj should be filled with the obj's current spec")
+
+					// mutate object
+					obj.SetLabels(map[string]string{
+						"foo": "bar",
+					})
+					return nil
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("kind registered in scheme (VerticalPodAutoscaler)", func() {
+			var (
+				vpaGVK schema.GroupVersionKind
+
+				currentVPA             *autoscalerv1beta2.VerticalPodAutoscaler
+				currentVPAUnstructured *unstructured.Unstructured
+			)
+
+			BeforeEach(func() {
+				vpaGVK = autoscalerv1beta2.SchemeGroupVersion.WithKind("VerticalPodAutoscaler")
+				obj.SetGroupVersionKind(vpaGVK)
+
+				currentVPA = &autoscalerv1beta2.VerticalPodAutoscaler{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+					Spec: autoscalerv1beta2.VerticalPodAutoscalerSpec{
+						TargetRef: &autoscalingv1.CrossVersionObjectReference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "kube-apiserver",
+						},
+					},
+				}
+
+				currentVPAUnstructured = &unstructured.Unstructured{}
+				tmpScheme := runtime.NewScheme()
+				Expect(autoscalerv1beta2.AddToScheme(tmpScheme)).To(Succeed(), "should be able to add autoscaler types to temporary scheme")
+				Expect(tmpScheme.Convert(currentVPA, currentVPAUnstructured, nil)).To(Succeed(), "should be able to convert VPA to unstructured")
+			})
+
+			It("should fallback to an unstructured get request and correctly create the object", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, gomock.AssignableToTypeOf(&unstructured.Unstructured{})).
+						Return(apierrors.NewNotFound(autoscalerv1beta2.Resource("verticalpodautoscalers"), name)),
+					c.EXPECT().Create(ctx, obj),
+				)
+
+				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+					Expect(obj.Object["spec"]).To(BeNil(), "obj should not be filled, as the object does not exist yet")
+					return nil
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should fallback to an unstructured get request and skip update (no changes)", func() {
+				c.EXPECT().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, gomock.AssignableToTypeOf(&unstructured.Unstructured{})).
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, o runtime.Object) error {
+						vpa, ok := o.(*unstructured.Unstructured)
+						Expect(ok).To(BeTrue())
+
+						currentVPAUnstructured.DeepCopyInto(vpa)
+						return nil
+					})
+
+				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+					Expect(obj).To(BeSemanticallyEqual(currentVPAUnstructured), "obj should be filled with the obj's current spec")
+					return nil
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should fallback to an unstructured get request and correctly update the object", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, gomock.AssignableToTypeOf(&unstructured.Unstructured{})).
+						DoAndReturn(func(ctx context.Context, key client.ObjectKey, o runtime.Object) error {
+							vpa, ok := o.(*unstructured.Unstructured)
+							Expect(ok).To(BeTrue())
+
+							currentVPAUnstructured.DeepCopyInto(vpa)
+							return nil
+						}),
+					c.EXPECT().Update(ctx, obj),
+				)
+
+				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+					Expect(obj).To(BeSemanticallyEqual(currentVPAUnstructured), "obj should be filled with the obj's current spec")
+
+					// mutate object
+					obj.SetLabels(map[string]string{
+						"foo": "bar",
+					})
+					return nil
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/test/matchers.go
+++ b/pkg/test/matchers.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+)
+
+// BeSemanticallyEqual returns a matcher that matches if actual and expected are semantically equal
+// by testing via apiequality.Semantic.DeepEqual().
+func BeSemanticallyEqual(expected interface{}) types.GomegaMatcher {
+	return &semanticallyEqualMatcher{
+		expected: expected,
+	}
+}
+
+type semanticallyEqualMatcher struct {
+	expected interface{}
+}
+
+func (m *semanticallyEqualMatcher) Match(actual interface{}) (success bool, err error) {
+	if actual == nil && m.expected == nil {
+		return false, fmt.Errorf("refusing to compare <nil> to <nil>.\nBe explicit and use BeNil() instead.  This is to avoid mistakes where both sides of an assertion are erroneously uninitialized")
+	}
+	return apiequality.Semantic.DeepEqual(actual, m.expected), nil
+}
+
+func (m *semanticallyEqualMatcher) FailureMessage(actual interface{}) (message string) {
+	actualString, actualOK := actual.(string)
+	expectedString, expectedOK := m.expected.(string)
+	if actualOK && expectedOK {
+		return format.MessageWithDiff(actualString, "to equal", expectedString)
+	}
+
+	return format.Message(actual, "to be semantically equal to", m.expected)
+}
+
+func (m *semanticallyEqualMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to be semantically equal to", m.expected)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds some more performance (and networking) optimisations, which become relevant, when using grm for quite large ManagedResources (like the `seed-bootstrap` chart).
1. It now also uses the caching target client for get calls before applying changes to the objects
2. It reduces the amount of unnecessary update calls by retaining some more metadata while merging and by using semantic equality to check if objects are changed.
3. It also fixes a problem, which caused mr reconciliation to break, if at least one of the objects cannot be mapped by the target rest mapper.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
