### PR TITLE
Inject labels into VolumeClaimTemplates of StatefulSets

### DIFF
--- a/pkg/controller/managedresources/controller_test.go
+++ b/pkg/controller/managedresources/controller_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedresources
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("Controller", func() {
+
+	Describe("#injectLabels", func() {
+		var (
+			obj, expected *unstructured.Unstructured
+			labels        map[string]string
+		)
+
+		BeforeEach(func() {
+			obj = &unstructured.Unstructured{Object: map[string]interface{}{}}
+			expected = obj.DeepCopy()
+		})
+
+		It("do nothing as labels is nil", func() {
+			labels = nil
+			Expect(injectLabels(obj, labels)).To(Succeed())
+			Expect(obj).To(Equal(expected))
+		})
+
+		It("do nothing as labels is empty", func() {
+			labels = map[string]string{}
+			Expect(injectLabels(obj, labels)).To(Succeed())
+			Expect(obj).To(Equal(expected))
+		})
+
+		It("should correctly inject labels into the object's metadata", func() {
+			labels = map[string]string{
+				"inject": "me",
+			}
+			expected.SetLabels(labels)
+
+			Expect(injectLabels(obj, labels)).To(Succeed())
+			Expect(obj).To(Equal(expected))
+		})
+
+		It("should correctly inject labels into the object's pod template's metadata", func() {
+			labels = map[string]string{
+				"inject": "me",
+			}
+
+			// add .spec.template to object
+			Expect(unstructured.SetNestedMap(obj.Object, map[string]interface{}{
+				"template": map[string]interface{}{},
+			}, "spec")).To(Succeed())
+
+			expected = obj.DeepCopy()
+			Expect(unstructured.SetNestedMap(expected.Object, map[string]interface{}{
+				"inject": "me",
+			}, "spec", "template", "metadata", "labels")).To(Succeed())
+			expected.SetLabels(labels)
+
+			Expect(injectLabels(obj, labels)).To(Succeed())
+			Expect(obj).To(Equal(expected))
+		})
+
+		It("should correctly inject labels into the object's volumeClaimTemplates' metadata", func() {
+			labels = map[string]string{
+				"inject": "me",
+			}
+
+			// add .spec.volumeClaimTemplates to object
+			Expect(unstructured.SetNestedMap(obj.Object, map[string]interface{}{
+				"volumeClaimTemplates": []interface{}{
+					map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "volume-claim-name",
+						},
+					},
+				},
+			}, "spec")).To(Succeed())
+
+			expected = obj.DeepCopy()
+			Expect(unstructured.SetNestedMap(expected.Object, map[string]interface{}{
+				"volumeClaimTemplates": []interface{}{
+					map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "volume-claim-name",
+							"labels": map[string]interface{}{
+								"inject": "me",
+							},
+						},
+					},
+				},
+			}, "spec")).To(Succeed())
+			expected.SetLabels(labels)
+
+			Expect(injectLabels(obj, labels)).To(Succeed())
+			Expect(obj).To(Equal(expected))
+		})
+	})
+
+})

--- a/pkg/controller/managedresources/merger.go
+++ b/pkg/controller/managedresources/merger.go
@@ -197,6 +197,11 @@ func mergeStatefulSet(scheme *runtime.Scheme, oldObj, newObj runtime.Object, pre
 		newStatefulSet.Spec.Replicas = oldStatefulSet.Spec.Replicas
 	}
 
+	// Do not overwrite a StatefulSet's '.spec.volumeClaimTemplates' field once the StatefulSet has been created as it is immutable
+	if !oldStatefulSet.CreationTimestamp.IsZero() {
+		newStatefulSet.Spec.VolumeClaimTemplates = oldStatefulSet.Spec.VolumeClaimTemplates
+	}
+
 	mergePodTemplate(&oldStatefulSet.Spec.Template, &oldStatefulSet.Spec.Template, preserveResources)
 
 	return scheme.Convert(newStatefulSet, newObj, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends the `injectLabels` functionality of grm to also inject the specified labels into `.spec.volumenClaimTemplates` of StatefulSets. Though, it only does so for newly created StatefulSets as the field is immutable.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`gardener-resource-manager` now also injects labels specified in `.spec.injectLabels` into the `.spec.volumeClaimTemplates` of new StatefulSets.
```
