### PR TITLE
Delete PVCs of StatefulSets

### DIFF
--- a/example/20-managedresource.yaml
+++ b/example/20-managedresource.yaml
@@ -63,3 +63,4 @@ spec:
 # forceOverwriteLabels: false
 # forceOverwriteAnnotations: false
 # keepObjects: false
+# deletePersistentVolumeClaims: false

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -69,6 +69,10 @@ type ManagedResourceSpec struct {
 	// Equivalences specifies possible group/kind equivalences for objects.
 	// +optional
 	Equivalences [][]metav1.GroupKind `json:"equivalences,omitempty"`
+	// DeletePersistentVolumeClaims specifies if PersistentVolumeClaims created by StatefulSets, which are managed by this
+	// resource, should also be deleted when the corresponding StatefulSet is deleted (defaults to false).
+	// +optional
+	DeletePersistentVolumeClaims *bool `json:"deletePersistentVolumeClaims,omitempty"`
 }
 
 // ManagedResourceStatus is the status of a managed resource.

--- a/pkg/apis/resources/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/resources/v1alpha1/zz_generated.deepcopy.go
@@ -148,6 +148,11 @@ func (in *ManagedResourceSpec) DeepCopyInto(out *ManagedResourceSpec) {
 			}
 		}
 	}
+	if in.DeletePersistentVolumeClaims != nil {
+		in, out := &in.DeletePersistentVolumeClaims, &out.DeletePersistentVolumeClaims
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/managedresources/cleaner.go
+++ b/pkg/controller/managedresources/cleaner.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedresources
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// cleanup tries to cleanup any resources created by the given object, that are left in the target cluster. It returns a
+// bool indicating whether there are still some deletions pending and an error if any occurred.
+func cleanup(ctx context.Context, c client.Client, scheme *runtime.Scheme, obj *unstructured.Unstructured, deletePVCs bool) error {
+	switch obj.GroupVersionKind().GroupKind() {
+	case appsv1.SchemeGroupVersion.WithKind("StatefulSet").GroupKind(), extensionsv1beta1.SchemeGroupVersion.WithKind("StatefulSet").GroupKind():
+		return cleanupStatefulSet(ctx, c, scheme, obj, deletePVCs)
+	}
+
+	return nil
+}
+
+// cleanupStatefulSet tries to delete all PVCs created by this StatefulSet if the ManagedResource is configured accordingly.
+func cleanupStatefulSet(ctx context.Context, c client.Client, scheme *runtime.Scheme, obj runtime.Object, deletePVCs bool) error {
+	if !deletePVCs {
+		return nil
+	}
+
+	errMsg := "failed cleaning up PersistentVolumeClaims of StatefulSet"
+
+	statefulSet := &appsv1.StatefulSet{}
+	if err := scheme.Convert(obj, statefulSet, nil); err != nil {
+		return fmt.Errorf("%s: could not convert object to StatefulSet: %v", errMsg, err)
+	}
+
+	if len(statefulSet.Spec.VolumeClaimTemplates) == 0 {
+		return nil
+	}
+
+	// the StatefulSet controller computes the labels for the PVCs by combining the labels given in the volumeClaimTemplate and the StatefulSet's selector
+	// with the selector labels taking precedence, so we can delete all PVCs by using the StatefulSet's selector.
+	// (ref: https://github.com/kubernetes/kubernetes/blob/d3a0c149a36b912a5c3ab3cc63047b1cbc758720/pkg/controller/statefulset/stateful_set_utils.go#L146-L152)
+	pvcLabels := statefulSet.Spec.Selector.MatchLabels
+
+	// first check, if there are any PVCs left to delete for this StatefulSet
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := c.List(ctx, pvcList, client.InNamespace(statefulSet.Namespace), client.MatchingLabels(pvcLabels)); err != nil {
+		return fmt.Errorf("%s: could not list PVCs of StatefulSet: %v", errMsg, err)
+	}
+	if len(pvcList.Items) == 0 {
+		return nil
+	}
+
+	if err := c.DeleteAllOf(ctx, &corev1.PersistentVolumeClaim{}, client.InNamespace(statefulSet.Namespace), client.MatchingLabels(pvcLabels)); err != nil {
+		return fmt.Errorf("%s: %v", errMsg, err)
+	}
+
+	return nil
+}

--- a/pkg/controller/managedresources/cleaner_test.go
+++ b/pkg/controller/managedresources/cleaner_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedresources
+
+import (
+	"context"
+	"fmt"
+
+	mockclient "github.com/gardener/gardener-resource-manager/pkg/mock/controller-runtime/client"
+
+	"github.com/golang/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("cleaner", func() {
+
+	Describe("#cleanupStatefulSet", func() {
+		var (
+			s    *runtime.Scheme
+			ctx  context.Context
+			ctrl *gomock.Controller
+			c    *mockclient.MockClient
+			sts  *appsv1.StatefulSet
+		)
+
+		BeforeEach(func() {
+			s = runtime.NewScheme()
+			Expect(appsv1.AddToScheme(s)).ToNot(HaveOccurred(), "schema add should succeed")
+
+			ctx = context.TODO()
+			ctrl = gomock.NewController(GinkgoT())
+			c = mockclient.NewMockClient(ctrl)
+
+			sts = &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo-ns",
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+					Replicas: pointer.Int32Ptr(1),
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+						{
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+								VolumeName:       "foo-pvc",
+								StorageClassName: pointer.StringPtr("ultra-fast"),
+							},
+						},
+					},
+				},
+			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should do nothing if deletePVCs is false", func() {
+			err := cleanupStatefulSet(ctx, c, s, sts, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should do nothing if conversion to appsv1.StatefulSet fails", func() {
+			s = runtime.NewScheme()
+
+			err := cleanupStatefulSet(ctx, c, s, sts, true)
+			Expect(err).To(MatchError(ContainSubstring("failed cleaning up PersistentVolumeClaims of StatefulSet: could not convert object to StatefulSet")))
+		})
+
+		It("should do nothing if .spec.volumeClaimTemplate is not set", func() {
+			sts.Spec.VolumeClaimTemplates = nil
+
+			err := cleanupStatefulSet(ctx, c, s, sts, true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should do nothing if list PVCs fails", func() {
+			fakeErr := fmt.Errorf("fake")
+
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaimList{}), client.InNamespace(sts.Namespace), client.MatchingLabels(sts.Spec.Selector.MatchLabels)).
+				DoAndReturn(func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+					return fakeErr
+				})
+
+			err := cleanupStatefulSet(ctx, c, s, sts, true)
+			Expect(err).To(MatchError(ContainSubstring(fakeErr.Error())))
+		})
+
+		It("should do nothing if all PVCs of the StatefulSet have already been deleted", func() {
+			c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaimList{}), client.InNamespace(sts.Namespace), client.MatchingLabels(sts.Spec.Selector.MatchLabels)).
+				DoAndReturn(func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+					return nil
+				})
+
+			err := cleanupStatefulSet(ctx, c, s, sts, true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should delete all PVCs of the StatefulSet", func() {
+			fakeErr := fmt.Errorf("fake")
+
+			gomock.InOrder(
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaimList{}), client.InNamespace(sts.Namespace), client.MatchingLabels(sts.Spec.Selector.MatchLabels)).
+					DoAndReturn(func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+						list.(*corev1.PersistentVolumeClaimList).Items = []corev1.PersistentVolumeClaim{
+							{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+									VolumeName:       "foo-pvc-foo-0",
+									StorageClassName: pointer.StringPtr("ultra-fast"),
+								},
+							},
+						}
+						return nil
+					}),
+				c.EXPECT().DeleteAllOf(ctx, gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaim{}), client.InNamespace(sts.Namespace), client.MatchingLabels(sts.Spec.Selector.MatchLabels)).
+					DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+						return fakeErr
+					}),
+			)
+
+			err := cleanupStatefulSet(ctx, c, s, sts, true)
+			Expect(err).To(MatchError(ContainSubstring(fakeErr.Error())))
+		})
+
+		It("should delete all PVCs of the StatefulSet", func() {
+			gomock.InOrder(
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaimList{}), client.InNamespace(sts.Namespace), client.MatchingLabels(sts.Spec.Selector.MatchLabels)).
+					DoAndReturn(func(_ context.Context, list runtime.Object, _ ...client.ListOption) error {
+						list.(*corev1.PersistentVolumeClaimList).Items = []corev1.PersistentVolumeClaim{
+							{
+								Spec: corev1.PersistentVolumeClaimSpec{
+									AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+									VolumeName:       "foo-pvc-foo-0",
+									StorageClassName: pointer.StringPtr("ultra-fast"),
+								},
+							},
+						}
+						return nil
+					}),
+				c.EXPECT().DeleteAllOf(ctx, gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaim{}), client.InNamespace(sts.Namespace), client.MatchingLabels(sts.Spec.Selector.MatchLabels)).
+					DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+						return nil
+					}),
+			)
+
+			err := cleanupStatefulSet(ctx, c, s, sts, true)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -122,7 +122,7 @@ var _ = Describe("utils", func() {
 					})
 
 				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
-					Expect(obj).To(BeSemanticallyEqual(currentDeploymentUnstructured), "obj should be filled with the obj's current spec")
+					Expect(obj).To(BeSemanticallyEqualTo(currentDeploymentUnstructured), "obj should be filled with the obj's current spec")
 					return nil
 				})
 
@@ -143,7 +143,7 @@ var _ = Describe("utils", func() {
 				)
 
 				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
-					Expect(obj).To(BeSemanticallyEqual(currentDeploymentUnstructured), "obj should be filled with the obj's current spec")
+					Expect(obj).To(BeSemanticallyEqualTo(currentDeploymentUnstructured), "obj should be filled with the obj's current spec")
 
 					// mutate object
 					obj.SetLabels(map[string]string{
@@ -214,7 +214,7 @@ var _ = Describe("utils", func() {
 					})
 
 				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
-					Expect(obj).To(BeSemanticallyEqual(currentVPAUnstructured), "obj should be filled with the obj's current spec")
+					Expect(obj).To(BeSemanticallyEqualTo(currentVPAUnstructured), "obj should be filled with the obj's current spec")
 					return nil
 				})
 
@@ -235,7 +235,7 @@ var _ = Describe("utils", func() {
 				)
 
 				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
-					Expect(obj).To(BeSemanticallyEqual(currentVPAUnstructured), "obj should be filled with the obj's current spec")
+					Expect(obj).To(BeSemanticallyEqualTo(currentVPAUnstructured), "obj should be filled with the obj's current spec")
 
 					// mutate object
 					obj.SetLabels(map[string]string{

--- a/pkg/manager/managedresources.go
+++ b/pkg/manager/managedresources.go
@@ -93,6 +93,11 @@ func (m *ManagedResource) KeepObjects(v bool) *ManagedResource {
 	return m
 }
 
+func (m *ManagedResource) DeletePersistentVolumeClaims(v bool) *ManagedResource {
+	m.resource.Spec.DeletePersistentVolumeClaims = &v
+	return m
+}
+
 func (m *ManagedResource) Reconcile(ctx context.Context) error {
 	resource := &resourcesv1alpha1.ManagedResource{
 		ObjectMeta: metav1.ObjectMeta{Name: m.resource.Name, Namespace: m.resource.Namespace},

--- a/pkg/test/matchers.go
+++ b/pkg/test/matchers.go
@@ -22,9 +22,9 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
 
-// BeSemanticallyEqual returns a matcher that matches if actual and expected are semantically equal
+// BeSemanticallyEqualTo returns a matcher that matches if actual and expected are semantically equal
 // by testing via apiequality.Semantic.DeepEqual().
-func BeSemanticallyEqual(expected interface{}) types.GomegaMatcher {
+func BeSemanticallyEqualTo(expected interface{}) types.GomegaMatcher {
 	return &semanticallyEqualMatcher{
 		expected: expected,
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, grm deletes PVCs belonging to StatefulSets, if the ManagedResource has `.spec.deletePersistentVolumeClaims=true`, when the corresponding StatefulSet is removed from the ManagedResource or the respective ManagedResource is deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
One thing, I am not so sure about, how to do it properly (feedback/ideas would be appreciated):

In order to be able to cleanup PVCs belonging to a StatefulSet, after it has been deleted, I am saving the StatefulSet before deleting it (we need `.spec.selector` from it for deleting the PVCs) here:
https://github.com/gardener/gardener-resource-manager/blob/8d73ce9bbabda106b24c5e5dc77efafffe3006fd/pkg/controller/managedresources/controller.go#L585-L595

However, if `DELETE statefulset` succeeds but any call during PVC cleanup fails, grm won't be able to delete the corresponding PVCs in the next retry, because it can't get the StatefulSet anymore and therefore doesn't know that it should still cleanup some PVCs.
Things, I have already considered:
- retry cleanup calls: I think, this would be not a good idea, because it would block the whole reconciliation
- save StatefulSet object in-memory: more implementation effort needed, problem would still persist, if grm panics / is evicted. Also, it can't be sure, that in the meanwhile the PVC is not reused again (i.e. a new StatefulSet might have been created after some backoff time) because object name `!=` object identity and we only store the objects' names in the MR status, not the `uid`.
- add the names of PVCs, that are still to be deleted to the MR status: problem with reuse by new/recreated StatefulSet from above persists.
- add selector of StatefulSets to MR status during deletion: this speaks against, grm's generic way of handling different resources. What if we need an additional field for cleanup of a different resource kind...

Long story short, I have no solution/idea, how to properly deal with this scenario. Also, I am not sure, if it's even worth considering it, or if this feature should be rather seen as a "best-effort cleanup".


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `ManagedResource` CRD features a new field `.spec.deletePersistentVolumeClaims`. If set to `true`, gardener-resource-manager will delete PVCs belonging to managed StatefulSets, when they are deleted.
```
