### PR TITLE
Fix falsy health checks

### DIFF
--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener-resource-manager/pkg/controller/managedresources"
 	"github.com/gardener/gardener-resource-manager/pkg/controller/managedresources/health"
 	logpkg "github.com/gardener/gardener-resource-manager/pkg/log"
+	managerpredicate "github.com/gardener/gardener-resource-manager/pkg/predicate"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/spf13/cobra"
@@ -224,7 +225,11 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 						}})
 					},
 				},
-				filter, health.ClassChangedPredicate(),
+				filter, managerpredicate.Or(
+					managerpredicate.ClassChangedPredicate(),
+					// start health checks immediately after MR has been reconciled
+					managerpredicate.ConditionStatusChanged(resourcesv1alpha1.ResourcesApplied),
+				),
 			); err != nil {
 				return fmt.Errorf("unable to watch ManagedResources: %+v", err)
 			}

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -114,6 +114,33 @@ const (
 	ConditionFalse ConditionStatus = "False"
 	// ConditionUnknown means that the controller can't decide if a resource is in the condition or not
 	ConditionUnknown ConditionStatus = "Unknown"
+	// ConditionProgressing means that the controller is currently acting on the resource and the condition is therefore progressing.
+	ConditionProgressing ConditionStatus = "Progressing"
+)
+
+// These are well-known reasons for ManagedResourceConditions.
+const (
+	// ConditionApplySucceeded indicates that the `ResourcesApplied` condition is `True`,
+	// because all resources have been applied successfully.
+	ConditionApplySucceeded = "ApplySucceeded"
+	// ConditionApplyFailed indicates that the `ResourcesApplied` condition is `False`,
+	// because applying the resources failed.
+	ConditionApplyFailed = "ApplyFailed"
+	// ConditionDecodingFailed indicates that the `ResourcesApplied` condition is `False`,
+	// because decoding the resources of the ManagedResource failed.
+	ConditionDecodingFailed = "DecodingFailed"
+	// ConditionApplyProgressing indicates that the `ResourcesApplied` condition is `Progressing`,
+	// because the resources are currently being reconciled.
+	ConditionApplyProgressing = "ApplyProgressing"
+	// ConditionDeletionFailed indicates that the `ResourcesApplied` condition is `False`,
+	// because deleting the resources failed.
+	ConditionDeletionFailed = "DeletionFailed"
+	// ConditionDeletionPending indicates that the `ResourcesApplied` condition is `Progressing`,
+	// because the deletion of some resources are still pending.
+	ConditionDeletionPending = "DeletionPending"
+	// ConditionHealthChecksPending indicates that the `ResourcesHealthy` condition is `Unknown`,
+	// because the health checks have not been completely executed yet for the current set of resources.
+	ConditionHealthChecksPending = "HealthChecksPending"
 )
 
 // ManagedResourceCondition describes the state of a deployment at a certain period.

--- a/pkg/controller/managedresources/sort.go
+++ b/pkg/controller/managedresources/sort.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedresources
+
+import (
+	"sort"
+
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+)
+
+var _ = sort.Interface(referenceSorter{})
+
+type referenceSorter struct {
+	keys []string
+	refs []resourcesv1alpha1.ObjectReference
+}
+
+func newReferenceSorter(refs []resourcesv1alpha1.ObjectReference) sort.Interface {
+	// compute keys only once
+	keys := make([]string, len(refs))
+	for i, ref := range refs {
+		keys[i] = objectKeyByReference(ref)
+	}
+
+	return referenceSorter{
+		keys: keys,
+		refs: refs,
+	}
+}
+
+func sortObjectReferences(refs []resourcesv1alpha1.ObjectReference) {
+	s := newReferenceSorter(refs)
+	sort.Sort(s)
+}
+
+func (r referenceSorter) Len() int {
+	return len(r.refs)
+}
+
+func (r referenceSorter) Less(i, j int) bool {
+	return r.keys[i] < r.keys[j]
+}
+
+func (r referenceSorter) Swap(i, j int) {
+	r.keys[i], r.keys[j] = r.keys[j], r.keys[i]
+	r.refs[i], r.refs[j] = r.refs[j], r.refs[i]
+}

--- a/pkg/controller/managedresources/sort_test.go
+++ b/pkg/controller/managedresources/sort_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedresources
+
+import (
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Reference sorter", func() {
+
+	var (
+		refs, refsBase []resourcesv1alpha1.ObjectReference
+	)
+
+	BeforeEach(func() {
+		refsBase = []resourcesv1alpha1.ObjectReference{
+			{
+				ObjectReference: corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Name:       "foo",
+					Namespace:  "bar",
+				},
+			},
+			{
+				ObjectReference: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "nginx",
+					Namespace:  "web",
+				},
+			},
+		}
+
+		// copy refs for assertions, as referenceSorter is sorting in-place
+		refs = append(refsBase[:0:0], refsBase...)
+	})
+
+	Describe("#sortObjectReferences", func() {
+		It("should correctly sort refs", func() {
+			sortObjectReferences(refs)
+			Expect(refs).To(Equal(refsBase))
+		})
+		It("should correctly sort refs (inverted order)", func() {
+			refs[0], refs[1] = refs[1], refs[0]
+			sortObjectReferences(refs)
+			Expect(refs).To(Equal(refsBase))
+		})
+	})
+
+	Describe("#newReferenceSorter", func() {
+		var (
+			sorter referenceSorter
+		)
+
+		BeforeEach(func() {
+			sorter = newReferenceSorter(refs).(referenceSorter)
+		})
+
+		It("should return the correct length", func() {
+			Expect(sorter.Len()).To(BeEquivalentTo(len(refsBase)))
+		})
+
+		It("should return the correct length (nil slice)", func() {
+			sorter = newReferenceSorter(nil).(referenceSorter)
+			Expect(sorter.Len()).To(BeEquivalentTo(0))
+		})
+
+		It("should calculate the correct keys for refs", func() {
+			Expect(refs).To(Equal([]resourcesv1alpha1.ObjectReference{
+				refsBase[0],
+				refsBase[1],
+			}))
+			Expect(sorter.keys).To(Equal([]string{
+				"/ConfigMap/bar/foo",
+				"apps/Deployment/web/nginx",
+			}))
+		})
+
+		It("should correctly compare refs", func() {
+			Expect(sorter.Less(0, 1)).To(BeTrue())
+		})
+
+		It("should correctly swap refs and keys", func() {
+			sorter.Swap(0, 1)
+			Expect(refs).To(Equal([]resourcesv1alpha1.ObjectReference{
+				refsBase[1],
+				refsBase[0],
+			}))
+			Expect(sorter.keys).To(Equal([]string{
+				"apps/Deployment/web/nginx",
+				"/ConfigMap/bar/foo",
+			}))
+		})
+	})
+
+})

--- a/pkg/predicate/class_changed.go
+++ b/pkg/predicate/class_changed.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package health
+package predicate
 
 import (
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
-
-var log = runtimelog.Log.WithName("gardener-resource-manager")
 
 var classChangedPredicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {

--- a/pkg/predicate/class_changed_test.go
+++ b/pkg/predicate/class_changed_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate_test
+
+import (
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	managerpredicate "github.com/gardener/gardener-resource-manager/pkg/predicate"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("Predicate", func() {
+	var (
+		managedResource *resourcesv1alpha1.ManagedResource
+		createEvent     event.CreateEvent
+		updateEvent     event.UpdateEvent
+		deleteEvent     event.DeleteEvent
+		genericEvent    event.GenericEvent
+	)
+
+	BeforeEach(func() {
+		managedResource = &resourcesv1alpha1.ManagedResource{
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				Class: pointer.StringPtr("shoot"),
+			},
+		}
+		createEvent = event.CreateEvent{
+			Object: managedResource,
+		}
+		updateEvent = event.UpdateEvent{
+			ObjectOld: managedResource,
+			ObjectNew: managedResource,
+		}
+		deleteEvent = event.DeleteEvent{
+			Object: managedResource,
+		}
+		genericEvent = event.GenericEvent{
+			Object: managedResource,
+		}
+	})
+
+	Describe("#ClassChangedPredicate", func() {
+		It("should not match on update (no change)", func() {
+			predicate := managerpredicate.ClassChangedPredicate()
+
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeFalse())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeTrue())
+		})
+
+		It("should not match on update (old not set)", func() {
+			updateEvent.ObjectOld = nil
+
+			predicate := managerpredicate.ClassChangedPredicate()
+
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeFalse())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeTrue())
+		})
+
+		It("should not match on update (old is not a ManagedResource)", func() {
+			updateEvent.ObjectOld = &corev1.Pod{}
+
+			predicate := managerpredicate.ClassChangedPredicate()
+
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeFalse())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeTrue())
+		})
+
+		It("should not match on update (new not set)", func() {
+			updateEvent.ObjectNew = nil
+
+			predicate := managerpredicate.ClassChangedPredicate()
+
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeFalse())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeTrue())
+		})
+
+		It("should not match on update (new is not a ManagedResource)", func() {
+			updateEvent.ObjectNew = &corev1.Pod{}
+
+			predicate := managerpredicate.ClassChangedPredicate()
+
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeFalse())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeTrue())
+		})
+
+		It("should match on update (class changed)", func() {
+			managedResourceNew := managedResource.DeepCopy()
+			managedResourceNew.Spec.Class = pointer.StringPtr("other")
+			updateEvent.ObjectNew = managedResourceNew
+
+			predicate := managerpredicate.ClassChangedPredicate()
+
+			Expect(predicate.Create(createEvent)).To(BeTrue())
+			Expect(predicate.Update(updateEvent)).To(BeTrue())
+			Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+			Expect(predicate.Generic(genericEvent)).To(BeTrue())
+		})
+	})
+})

--- a/pkg/predicate/condition_status.go
+++ b/pkg/predicate/condition_status.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	resourcesv1alpha1helper "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1/helper"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ConditionStatusChanged is a predicate that detects changes to the status of a Condition with a given type.
+func ConditionStatusChanged(conditionType resourcesv1alpha1.ConditionType) predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil {
+				log.Error(nil, "Update event has no old runtime object to update", "event", e)
+				return false
+			}
+			if e.ObjectNew == nil {
+				log.Error(nil, "Update event has no new runtime object for update", "event", e)
+				return false
+			}
+
+			old, ok := e.ObjectOld.(*resourcesv1alpha1.ManagedResource)
+			if !ok {
+				log.Error(nil, "Update event old runtime object cannot be converted to ManagedResource", "event", e)
+				return false
+			}
+			new, ok := e.ObjectNew.(*resourcesv1alpha1.ManagedResource)
+			if !ok {
+				log.Error(nil, "Update event new runtime object cannot be converted to ManagedResource", "event", e)
+				return false
+			}
+
+			oldCondition := resourcesv1alpha1helper.GetCondition(old.Status.Conditions, conditionType)
+			newCondition := resourcesv1alpha1helper.GetCondition(new.Status.Conditions, conditionType)
+
+			if oldCondition == nil {
+				// trigger if condition was added
+				return newCondition != nil
+			}
+
+			if newCondition == nil {
+				return true // condition was removed
+			}
+
+			return oldCondition.Status != newCondition.Status
+		},
+	}
+}

--- a/pkg/predicate/condition_status_test.go
+++ b/pkg/predicate/condition_status_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate_test
+
+import (
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	resourcesv1alpha1helper "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1/helper"
+	managerpredicate "github.com/gardener/gardener-resource-manager/pkg/predicate"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("#ConditionStatusChanged", func() {
+	var (
+		managedResource *resourcesv1alpha1.ManagedResource
+		createEvent     event.CreateEvent
+		updateEvent     event.UpdateEvent
+		deleteEvent     event.DeleteEvent
+		genericEvent    event.GenericEvent
+		conditionType   resourcesv1alpha1.ConditionType
+	)
+
+	BeforeEach(func() {
+		managedResource = &resourcesv1alpha1.ManagedResource{
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				Class: pointer.StringPtr("shoot"),
+			},
+		}
+		createEvent = event.CreateEvent{
+			Object: managedResource,
+		}
+		updateEvent = event.UpdateEvent{
+			ObjectOld: managedResource,
+			ObjectNew: managedResource,
+		}
+		deleteEvent = event.DeleteEvent{
+			Object: managedResource,
+		}
+		genericEvent = event.GenericEvent{
+			Object: managedResource,
+		}
+
+		conditionType = resourcesv1alpha1.ResourcesApplied
+	})
+
+	It("should not match on update (no change)", func() {
+		predicate := managerpredicate.ConditionStatusChanged(conditionType)
+
+		Expect(predicate.Create(createEvent)).To(BeTrue())
+		Expect(predicate.Update(updateEvent)).To(BeFalse())
+		Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+		Expect(predicate.Generic(genericEvent)).To(BeTrue())
+	})
+
+	It("should not match on update (old not set)", func() {
+		updateEvent.ObjectOld = nil
+
+		predicate := managerpredicate.ConditionStatusChanged(conditionType)
+
+		Expect(predicate.Create(createEvent)).To(BeTrue())
+		Expect(predicate.Update(updateEvent)).To(BeFalse())
+		Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+		Expect(predicate.Generic(genericEvent)).To(BeTrue())
+	})
+
+	It("should not match on update (old is not a ManagedResource)", func() {
+		updateEvent.ObjectOld = &corev1.Pod{}
+
+		predicate := managerpredicate.ConditionStatusChanged(conditionType)
+
+		Expect(predicate.Create(createEvent)).To(BeTrue())
+		Expect(predicate.Update(updateEvent)).To(BeFalse())
+		Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+		Expect(predicate.Generic(genericEvent)).To(BeTrue())
+	})
+
+	It("should not match on update (new not set)", func() {
+		updateEvent.ObjectNew = nil
+
+		predicate := managerpredicate.ConditionStatusChanged(conditionType)
+
+		Expect(predicate.Create(createEvent)).To(BeTrue())
+		Expect(predicate.Update(updateEvent)).To(BeFalse())
+		Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+		Expect(predicate.Generic(genericEvent)).To(BeTrue())
+	})
+
+	It("should not match on update (new is not a ManagedResource)", func() {
+		updateEvent.ObjectNew = &corev1.Pod{}
+
+		predicate := managerpredicate.ConditionStatusChanged(conditionType)
+
+		Expect(predicate.Create(createEvent)).To(BeTrue())
+		Expect(predicate.Update(updateEvent)).To(BeFalse())
+		Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+		Expect(predicate.Generic(genericEvent)).To(BeTrue())
+	})
+
+	It("should match on update (condition added)", func() {
+		condition := resourcesv1alpha1helper.InitCondition(conditionType)
+		managedResourceNew := managedResource.DeepCopy()
+		condition.Status = resourcesv1alpha1.ConditionTrue
+		managedResourceNew.Status.Conditions = []resourcesv1alpha1.ManagedResourceCondition{condition}
+		updateEvent.ObjectNew = managedResourceNew
+
+		predicate := managerpredicate.ConditionStatusChanged(conditionType)
+
+		Expect(predicate.Create(createEvent)).To(BeTrue())
+		Expect(predicate.Update(updateEvent)).To(BeTrue())
+		Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+		Expect(predicate.Generic(genericEvent)).To(BeTrue())
+	})
+
+	It("should match on update (condition removed)", func() {
+		condition := resourcesv1alpha1helper.InitCondition(conditionType)
+		condition.Status = resourcesv1alpha1.ConditionTrue
+		managedResourceNew := managedResource.DeepCopy()
+		managedResource.Status.Conditions = []resourcesv1alpha1.ManagedResourceCondition{condition}
+		updateEvent.ObjectNew = managedResourceNew
+
+		predicate := managerpredicate.ConditionStatusChanged(conditionType)
+
+		Expect(predicate.Create(createEvent)).To(BeTrue())
+		Expect(predicate.Update(updateEvent)).To(BeTrue())
+		Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+		Expect(predicate.Generic(genericEvent)).To(BeTrue())
+	})
+
+	It("should match on update (condition status changed)", func() {
+		condition := resourcesv1alpha1helper.InitCondition(conditionType)
+		condition.Status = resourcesv1alpha1.ConditionProgressing
+		managedResource.Status.Conditions = []resourcesv1alpha1.ManagedResourceCondition{condition}
+
+		managedResourceNew := managedResource.DeepCopy()
+		condition.Status = resourcesv1alpha1.ConditionTrue
+		managedResourceNew.Status.Conditions = []resourcesv1alpha1.ManagedResourceCondition{condition}
+		updateEvent.ObjectNew = managedResourceNew
+
+		predicate := managerpredicate.ConditionStatusChanged(conditionType)
+
+		Expect(predicate.Create(createEvent)).To(BeTrue())
+		Expect(predicate.Update(updateEvent)).To(BeTrue())
+		Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+		Expect(predicate.Generic(genericEvent)).To(BeTrue())
+	})
+})

--- a/pkg/predicate/or.go
+++ b/pkg/predicate/or.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+type or struct {
+	predicates []predicate.Predicate
+}
+
+func (o *or) orRange(f func(predicate.Predicate) bool) bool {
+	for _, p := range o.predicates {
+		if f(p) {
+			return true
+		}
+	}
+	return false
+}
+
+// Create implements Predicate.
+func (o *or) Create(event event.CreateEvent) bool {
+	return o.orRange(func(p predicate.Predicate) bool { return p.Create(event) })
+}
+
+// Delete implements Predicate.
+func (o *or) Delete(event event.DeleteEvent) bool {
+	return o.orRange(func(p predicate.Predicate) bool { return p.Delete(event) })
+}
+
+// Update implements Predicate.
+func (o *or) Update(event event.UpdateEvent) bool {
+	return o.orRange(func(p predicate.Predicate) bool { return p.Update(event) })
+}
+
+// Generic implements Predicate.
+func (o *or) Generic(event event.GenericEvent) bool {
+	return o.orRange(func(p predicate.Predicate) bool { return p.Generic(event) })
+}
+
+// InjectFunc implements Injector.
+func (o *or) InjectFunc(f inject.Func) error {
+	for _, p := range o.predicates {
+		if err := f(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Or builds a logical OR gate of passed predicates.
+func Or(predicates ...predicate.Predicate) predicate.Predicate {
+	return &or{predicates}
+}

--- a/pkg/predicate/or_test.go
+++ b/pkg/predicate/or_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate_test
+
+import (
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	managerpredicate "github.com/gardener/gardener-resource-manager/pkg/predicate"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ = Describe("#Or", func() {
+	var (
+		managedResource               *resourcesv1alpha1.ManagedResource
+		createEvent                   event.CreateEvent
+		updateEvent                   event.UpdateEvent
+		deleteEvent                   event.DeleteEvent
+		genericEvent                  event.GenericEvent
+		falsePredicate, truePredicate predicate.Predicate
+	)
+
+	BeforeEach(func() {
+		managedResource = &resourcesv1alpha1.ManagedResource{
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				Class: pointer.StringPtr("shoot"),
+			},
+		}
+		createEvent = event.CreateEvent{
+			Object: managedResource,
+		}
+		updateEvent = event.UpdateEvent{
+			ObjectOld: managedResource,
+			ObjectNew: managedResource,
+		}
+		deleteEvent = event.DeleteEvent{
+			Object: managedResource,
+		}
+		genericEvent = event.GenericEvent{
+			Object: managedResource,
+		}
+
+		falsePredicate = predicate.Funcs{
+			CreateFunc:  func(_ event.CreateEvent) bool { return false },
+			DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+			UpdateFunc:  func(_ event.UpdateEvent) bool { return false },
+			GenericFunc: func(_ event.GenericEvent) bool { return false },
+		}
+		truePredicate = predicate.Funcs{
+			CreateFunc:  func(_ event.CreateEvent) bool { return true },
+			DeleteFunc:  func(_ event.DeleteEvent) bool { return true },
+			UpdateFunc:  func(_ event.UpdateEvent) bool { return true },
+			GenericFunc: func(_ event.GenericEvent) bool { return true },
+		}
+	})
+
+	It("should not match if none matches", func() {
+		predicate := managerpredicate.Or(falsePredicate, falsePredicate)
+
+		Expect(predicate.Create(createEvent)).To(BeFalse())
+		Expect(predicate.Update(updateEvent)).To(BeFalse())
+		Expect(predicate.Delete(deleteEvent)).To(BeFalse())
+		Expect(predicate.Generic(genericEvent)).To(BeFalse())
+	})
+
+	It("should match if one matches", func() {
+		predicate := managerpredicate.Or(falsePredicate, truePredicate)
+
+		Expect(predicate.Create(createEvent)).To(BeTrue())
+		Expect(predicate.Update(updateEvent)).To(BeTrue())
+		Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+		Expect(predicate.Generic(genericEvent)).To(BeTrue())
+	})
+
+	It("should match if all match", func() {
+		predicate := managerpredicate.Or(truePredicate, truePredicate)
+
+		Expect(predicate.Create(createEvent)).To(BeTrue())
+		Expect(predicate.Update(updateEvent)).To(BeTrue())
+		Expect(predicate.Delete(deleteEvent)).To(BeTrue())
+		Expect(predicate.Generic(genericEvent)).To(BeTrue())
+	})
+})

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
+
+var log = runtimelog.Log.WithName("gardener-resource-manager")

--- a/pkg/predicate/predicate_suite_test.go
+++ b/pkg/predicate/predicate_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestPredicate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Predicate Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Before, `grm`'s MR controller and health controller were acting on MRs independent of each other / in parallel.
This could lead to a situation, were the health controller checks the resource first, sees no resources in `.status.resources` and therefore sets the `ResourcesHealthy` condition to `True` immediately. Later the MR controller successfully applies the resources and sets the `ResourcesApplied` condition to `True`. Now the MR has both conditions set to `True`, which indicates, that is is completely reconciled and healthy, although resources may still be creating (e.g. Pods for a Deployment). Later the health controller will check the resource again and correct this false condition.

This means, for up to `--health-sync-period` the managed resource may indicate a false health status, which is problematic for controllers waiting for a MR to be "Ready" (for example gardenlet's `ControllerInstallation` controller).

With this PR, the MR controller invalidates the `ResourcesHealthy` condition (i.e. sets it to `Progressing`) and the health checks are skipped until the `ResourcesApplied` condition is set to `True`, which indicates that the resource is now fully reconciled.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I fixed a bug along the way, which I introduced in #47, which caused ignored resources not to be created.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
A bug has been fixed, which could lead to a situation, where a `ManagedResource` is falsely indicating a "Ready" state for a short period of time.
```
