### PR TITLE
Remove finalizers from secret when reference is removed

### DIFF
--- a/pkg/controller/managedresources/filter.go
+++ b/pkg/controller/managedresources/filter.go
@@ -95,7 +95,7 @@ func (f *ClassFilter) Active(o runtime.Object) (action bool, responsible bool) {
 			}
 		}
 	}
-	action = (!busy && responsible)
+	action = !busy && responsible
 	return
 }
 

--- a/pkg/controller/managedresources/secret_controller.go
+++ b/pkg/controller/managedresources/secret_controller.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedresources
+
+import (
+	"context"
+	"time"
+
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener-resource-manager/pkg/controller/utils"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// SecretSecretReconciler adds/removes finalizers to/from secrets referenced by ManagedResources.
+type SecretReconciler struct {
+	log    logr.Logger
+	class  *ClassFilter
+	client client.Client
+	ctx    context.Context
+}
+
+// InjectClient injects a client into the reconciler.
+func (r *SecretReconciler) InjectClient(client client.Client) error {
+	r.client = client
+	return nil
+}
+
+// InjectStopChannel injects a stop channel into the reconciler.
+func (r *SecretReconciler) InjectStopChannel(stopCh <-chan struct{}) error {
+	r.ctx = utils.ContextFromStopChannel(stopCh)
+	return nil
+}
+
+// NewSecretReconciler creates a new secret reconciler.
+func NewSecretReconciler(log logr.Logger, class *ClassFilter) *SecretReconciler {
+	return &SecretReconciler{
+		log:   log,
+		class: class,
+	}
+}
+
+// Reconcile implements `reconcile.SecretReconciler`.
+func (r *SecretReconciler) Reconcile(req reconcile.Request) (reconcile.Result, error) {
+	log := r.log.WithValues("secret", req)
+
+	secret := &corev1.Secret{}
+	if err := r.client.Get(r.ctx, req.NamespacedName, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Stopping reconciliation of Secret, as it has been deleted")
+			return reconcile.Result{}, nil
+		}
+		log.Error(err, "Could not fetch Secret")
+		return reconcile.Result{}, err
+	}
+
+	resourceList := &resourcesv1alpha1.ManagedResourceList{}
+	if err := r.client.List(r.ctx, resourceList, client.InNamespace(secret.Namespace)); err != nil {
+		log.Error(err, "Could not fetch ManagedResources in namespace of ManagedResource")
+		return reconcile.Result{}, err
+	}
+
+	// check if there is at least one ManagedResource this controller is responsible for and which references this secret
+	secretIsReferenced := false
+	for _, resource := range resourceList.Items {
+		for _, ref := range resource.Spec.SecretRefs {
+			// check if we are responsible for this MR, class might have changed, then we need to remove our finalizer
+			if ref.Name == secret.Name && r.class.Responsible(&resource) {
+				secretIsReferenced = true
+				break
+			}
+		}
+	}
+
+	controllerFinalizer := r.class.FinalizerName()
+	secretFinalizers := sets.NewString(secret.Finalizers...)
+	addFinalizer, removeFinalizer := false, false
+	if secretIsReferenced && !secretFinalizers.Has(controllerFinalizer) {
+		addFinalizer = true
+		log.Info("adding finalizer to secret because it is referenced by a ManagedResource",
+			"finalizer", controllerFinalizer)
+	} else if !secretIsReferenced && secretFinalizers.Has(controllerFinalizer) {
+		removeFinalizer = true
+		log.Info("removing finalizer from secret because it is not referenced by a ManagedResource of this class",
+			"finalizer", controllerFinalizer)
+	}
+
+	if addFinalizer || removeFinalizer {
+		if err := utils.TryUpdate(r.ctx, retry.DefaultBackoff, r.client, secret, func() error {
+			secretFinalizers := sets.NewString(secret.Finalizers...)
+			if addFinalizer {
+				secretFinalizers.Insert(controllerFinalizer)
+			} else if removeFinalizer {
+				secretFinalizers.Delete(controllerFinalizer)
+			}
+			secret.Finalizers = secretFinalizers.UnsortedList()
+			return nil
+		}); client.IgnoreNotFound(err) != nil {
+			r.log.Error(err, "failed to update finalizers of secret")
+			// dont' run into exponential backoff for adding/removing finalizers
+			return reconcile.Result{RequeueAfter: 5 * time.Second}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/managedresources/secret_controller_test.go
+++ b/pkg/controller/managedresources/secret_controller_test.go
@@ -1,0 +1,397 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managedresources_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener-resource-manager/pkg/controller/managedresources"
+	mockclient "github.com/gardener/gardener-resource-manager/pkg/mock/controller-runtime/client"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+var _ = Describe("SecretReconciler", func() {
+	var (
+		ctrl *gomock.Controller
+		c    *mockclient.MockClient
+
+		r         *managedresources.SecretReconciler
+		filter    *managedresources.ClassFilter
+		secret    *corev1.Secret
+		secretReq reconcile.Request
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+
+		filter = managedresources.NewClassFilter("seed")
+		r = managedresources.NewSecretReconciler(log.NullLogger{}, filter)
+
+		Expect(inject.ClientInto(c, r)).To(BeTrue())
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "mr-ns",
+				Name:      "mr-secret",
+			},
+		}
+		secretReq = reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: secret.Namespace,
+			Name:      secret.Name,
+		}}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#InjectStopChannel", func() {
+		It("should be able to inject a stop channel", func() {
+			Expect(inject.StopChannelInto(context.TODO().Done(), r)).To(BeTrue())
+		})
+	})
+
+	Describe("#Reconcile", func() {
+		It("should do nothing if the secret has been deleted", func() {
+			c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				Return(apierrors.NewNotFound(corev1.Resource("secrets"), secret.Name))
+
+			res, err := r.Reconcile(secretReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{
+				Requeue: false,
+			}))
+		})
+
+		It("should do nothing if secret get fails", func() {
+			fakeErr := fmt.Errorf("fake")
+
+			c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				Return(fakeErr)
+
+			_, err := r.Reconcile(secretReq)
+			Expect(err).To(MatchError(ContainSubstring("fake")))
+		})
+
+		It("should do nothing if MR list fails", func() {
+			fakeErr := fmt.Errorf("fake")
+
+			gomock.InOrder(
+				c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						secret.DeepCopyInto(obj.(*corev1.Secret))
+						return nil
+					}),
+				c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+					Return(fakeErr),
+			)
+
+			_, err := r.Reconcile(secretReq)
+			Expect(err).To(MatchError(ContainSubstring("fake")))
+		})
+
+		It("should do nothing if there is no MR in namespace", func() {
+			gomock.InOrder(
+				c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						secret.DeepCopyInto(obj.(*corev1.Secret))
+						return nil
+					}),
+				c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+					Return(nil),
+			)
+
+			res, err := r.Reconcile(secretReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{
+				Requeue: false,
+			}))
+		})
+
+		It("should do nothing if there is no MR which we are responsible for", func() {
+			mrs := []resourcesv1alpha1.ManagedResource{{
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class: pointer.StringPtr("other"),
+					SecretRefs: []corev1.LocalObjectReference{{
+						Name: "foo",
+					}},
+				},
+			}}
+
+			gomock.InOrder(
+				c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						secret.DeepCopyInto(obj.(*corev1.Secret))
+						return nil
+					}),
+				c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+					DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+						list.(*resourcesv1alpha1.ManagedResourceList).Items = mrs
+						return nil
+					}),
+			)
+
+			res, err := r.Reconcile(secretReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{
+				Requeue: false,
+			}))
+		})
+
+		It("should do nothing if there is no MR referencing this secret", func() {
+			mrs := []resourcesv1alpha1.ManagedResource{{
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class: pointer.StringPtr(filter.ResourceClass()),
+					SecretRefs: []corev1.LocalObjectReference{{
+						Name: "foo",
+					}},
+				},
+			}}
+
+			gomock.InOrder(
+				c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+						secret.DeepCopyInto(obj.(*corev1.Secret))
+						return nil
+					}),
+				c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+					DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+						list.(*resourcesv1alpha1.ManagedResourceList).Items = mrs
+						return nil
+					}),
+			)
+
+			res, err := r.Reconcile(secretReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{
+				Requeue: false,
+			}))
+		})
+
+		It("should do nothing if finalizer was already added", func() {
+			secret.Finalizers = []string{filter.FinalizerName()}
+
+			mrs := []resourcesv1alpha1.ManagedResource{{
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class: pointer.StringPtr(filter.ResourceClass()),
+					SecretRefs: []corev1.LocalObjectReference{{
+						Name: secret.Name,
+					}},
+				},
+			}}
+
+			c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					secret.DeepCopyInto(obj.(*corev1.Secret))
+					return nil
+				})
+			c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+				DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+					list.(*resourcesv1alpha1.ManagedResourceList).Items = mrs
+					return nil
+				})
+
+			res, err := r.Reconcile(secretReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{
+				Requeue: false,
+			}))
+		})
+
+		It("should add finalizer to secret if referenced by MR", func() {
+			mrs := []resourcesv1alpha1.ManagedResource{{
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class: pointer.StringPtr(filter.ResourceClass()),
+					SecretRefs: []corev1.LocalObjectReference{{
+						Name: secret.Name,
+					}},
+				},
+			}}
+
+			c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					secret.DeepCopyInto(obj.(*corev1.Secret))
+					return nil
+				}).Times(2)
+			c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+				DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+					list.(*resourcesv1alpha1.ManagedResourceList).Items = mrs
+					return nil
+				})
+			c.EXPECT().Update(nil, gomock.AssignableToTypeOf(secret)).
+				DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+					s := obj.(*corev1.Secret)
+					Expect(s.Finalizers).To(ConsistOf(filter.FinalizerName()))
+					return nil
+				})
+
+			res, err := r.Reconcile(secretReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{
+				Requeue: false,
+			}))
+		})
+
+		It("should do nothing if finalizer was already removed", func() {
+			mrs := []resourcesv1alpha1.ManagedResource{{
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class:      pointer.StringPtr(filter.ResourceClass()),
+					SecretRefs: []corev1.LocalObjectReference{},
+				},
+			}}
+
+			c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					secret.DeepCopyInto(obj.(*corev1.Secret))
+					return nil
+				})
+			c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+				DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+					list.(*resourcesv1alpha1.ManagedResourceList).Items = mrs
+					return nil
+				})
+
+			res, err := r.Reconcile(secretReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{
+				Requeue: false,
+			}))
+		})
+
+		It("should remove finalizer from secret if reference was removed", func() {
+			secret.Finalizers = []string{filter.FinalizerName()}
+
+			mrs := []resourcesv1alpha1.ManagedResource{{
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class:      pointer.StringPtr(filter.ResourceClass()),
+					SecretRefs: []corev1.LocalObjectReference{},
+				},
+			}}
+
+			c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					secret.DeepCopyInto(obj.(*corev1.Secret))
+					return nil
+				}).Times(2)
+			c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+				DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+					list.(*resourcesv1alpha1.ManagedResourceList).Items = mrs
+					return nil
+				})
+			c.EXPECT().Update(nil, gomock.AssignableToTypeOf(secret)).
+				DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+					s := obj.(*corev1.Secret)
+					Expect(s.Finalizers).To(BeEmpty())
+					return nil
+				})
+
+			res, err := r.Reconcile(secretReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{
+				Requeue: false,
+			}))
+		})
+
+		It("should remove finalizer from secret if class changed", func() {
+			secret.Finalizers = []string{filter.FinalizerName()}
+
+			mrs := []resourcesv1alpha1.ManagedResource{{
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class: pointer.StringPtr("other"),
+					SecretRefs: []corev1.LocalObjectReference{{
+						Name: secret.Name,
+					}},
+				},
+			}}
+
+			c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					secret.DeepCopyInto(obj.(*corev1.Secret))
+					return nil
+				}).Times(2)
+			c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+				DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+					list.(*resourcesv1alpha1.ManagedResourceList).Items = mrs
+					return nil
+				})
+			c.EXPECT().Update(nil, gomock.AssignableToTypeOf(secret)).
+				DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+					s := obj.(*corev1.Secret)
+					Expect(s.Finalizers).To(BeEmpty())
+					return nil
+				})
+
+			res, err := r.Reconcile(secretReq)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(reconcile.Result{
+				Requeue: false,
+			}))
+		})
+
+		It("should fail if secret update fails", func() {
+			fakeErr := fmt.Errorf("fake")
+
+			secret.Finalizers = []string{filter.FinalizerName()}
+
+			mrs := []resourcesv1alpha1.ManagedResource{{
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					Class: pointer.StringPtr("other"),
+					SecretRefs: []corev1.LocalObjectReference{{
+						Name: secret.Name,
+					}},
+				},
+			}}
+
+			c.EXPECT().Get(nil, secretReq.NamespacedName, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+					secret.DeepCopyInto(obj.(*corev1.Secret))
+					return nil
+				}).Times(2)
+			c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+				DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+					list.(*resourcesv1alpha1.ManagedResourceList).Items = mrs
+					return nil
+				})
+			c.EXPECT().Update(nil, gomock.AssignableToTypeOf(secret)).
+				DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+					return fakeErr
+				})
+
+			res, err := r.Reconcile(secretReq)
+			Expect(err).To(MatchError(ContainSubstring("fake")))
+			Expect(res).To(Equal(reconcile.Result{
+				RequeueAfter: 5 * time.Second,
+			}))
+		})
+	})
+})

--- a/pkg/controller/utils/context.go
+++ b/pkg/controller/utils/context.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "context"
+
+// ContextFromStopChannel creates a new context from a given stop channel.
+func ContextFromStopChannel(stopCh <-chan struct{}) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		defer cancel()
+		<-stopCh
+	}()
+
+	return ctx
+}

--- a/pkg/mapper/mapper_suite_test.go
+++ b/pkg/mapper/mapper_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapper_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMapper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Mapper Suite")
+}

--- a/pkg/mapper/to_mr_test.go
+++ b/pkg/mapper/to_mr_test.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapper_test
+
+import (
+	"context"
+	"fmt"
+
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener-resource-manager/pkg/controller/managedresources"
+	"github.com/gardener/gardener-resource-manager/pkg/mapper"
+	mockclient "github.com/gardener/gardener-resource-manager/pkg/mock/controller-runtime/client"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+var _ = Describe("#SecretToManagedResourceMapper", func() {
+	var (
+		c      *mockclient.MockClient
+		ctrl   *gomock.Controller
+		m      handler.Mapper
+		secret *corev1.Secret
+		filter *managedresources.ClassFilter
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mr-secret",
+				Namespace: "mr-namespace",
+			},
+		}
+
+		filter = managedresources.NewClassFilter("seed")
+
+		m = mapper.SecretToManagedResourceMapper(filter)
+
+		Expect(inject.ClientInto(c, m)).To(BeTrue())
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("should be able to inject stop channel", func() {
+		Expect(inject.StopChannelInto(context.TODO().Done(), m)).To(BeTrue())
+	})
+
+	It("should do nothing, if Object is nil", func() {
+		requests := m.Map(handler.MapObject{})
+		Expect(requests).To(BeEmpty())
+	})
+
+	It("should do nothing, if Object is not a Secret", func() {
+		requests := m.Map(handler.MapObject{
+			Object: &corev1.Pod{},
+		})
+		Expect(requests).To(BeEmpty())
+	})
+
+	It("should do nothing, if list fails", func() {
+		c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+			Return(fmt.Errorf("fake"))
+
+		requests := m.Map(handler.MapObject{
+			Object: secret,
+		})
+		Expect(requests).To(BeEmpty())
+	})
+
+	It("should do nothing, if there are no ManagedResources", func() {
+		c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace))
+
+		requests := m.Map(handler.MapObject{
+			Object: secret,
+		})
+		Expect(requests).To(BeEmpty())
+	})
+
+	It("should do nothing, if there are no ManagedResources we are responsible for", func() {
+		mr := resourcesv1alpha1.ManagedResource{
+			Spec: resourcesv1alpha1.ManagedResourceSpec{Class: pointer.StringPtr("other")},
+		}
+
+		c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+			DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				list.(*resourcesv1alpha1.ManagedResourceList).Items = []resourcesv1alpha1.ManagedResource{mr}
+				return nil
+			})
+
+		requests := m.Map(handler.MapObject{
+			Object: secret,
+		})
+		Expect(requests).To(BeEmpty())
+	})
+
+	It("should correctly map to ManagedResources that reference the secret", func() {
+		mr := resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mr",
+				Namespace: secret.Namespace,
+			},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				Class:      pointer.StringPtr(filter.ResourceClass()),
+				SecretRefs: []corev1.LocalObjectReference{{Name: secret.Name}},
+			},
+		}
+
+		c.EXPECT().List(nil, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResourceList{}), client.InNamespace(secret.Namespace)).
+			DoAndReturn(func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				list.(*resourcesv1alpha1.ManagedResourceList).Items = []resourcesv1alpha1.ManagedResource{mr}
+				return nil
+			})
+
+		requests := m.Map(handler.MapObject{
+			Object: secret,
+		})
+		Expect(requests).To(ConsistOf(
+			reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      mr.Name,
+				Namespace: mr.Namespace,
+			}},
+		))
+	})
+})

--- a/pkg/mapper/to_secret.go
+++ b/pkg/mapper/to_secret.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapper
+
+import (
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type managedResourceToSecretsMapper struct{}
+
+func (m *managedResourceToSecretsMapper) Map(obj handler.MapObject) []reconcile.Request {
+	if obj.Object == nil {
+		return nil
+	}
+
+	resource, ok := obj.Object.(*resourcesv1alpha1.ManagedResource)
+	if !ok {
+		return nil
+	}
+
+	var requests []reconcile.Request
+
+	for _, ref := range resource.Spec.SecretRefs {
+		if ref.Name != "" {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      ref.Name,
+					Namespace: resource.Namespace,
+				},
+			})
+		}
+	}
+
+	return requests
+}
+
+// ManagedResourceToSecretsMapper returns a mapper that maps events for ManagedResources to their referenced secrets.
+func ManagedResourceToSecretsMapper() handler.Mapper {
+	return &managedResourceToSecretsMapper{}
+}

--- a/pkg/mapper/to_secret_test.go
+++ b/pkg/mapper/to_secret_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapper_test
+
+import (
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener-resource-manager/pkg/mapper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("#ManagedResourceToSecretsMapper", func() {
+	var (
+		m handler.Mapper
+	)
+
+	BeforeEach(func() {
+		m = mapper.ManagedResourceToSecretsMapper()
+	})
+
+	It("should do nothing, if Object is nil", func() {
+		requests := m.Map(handler.MapObject{})
+		Expect(requests).To(BeEmpty())
+	})
+
+	It("should do nothing, if Object is not a ManagedResource", func() {
+		requests := m.Map(handler.MapObject{
+			Object: &corev1.Pod{},
+		})
+		Expect(requests).To(BeEmpty())
+	})
+
+	It("should map to all secrets referenced by ManagedResource", func() {
+		mr := &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "bar",
+			},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				SecretRefs: []corev1.LocalObjectReference{
+					{Name: "secret-one"},
+					{Name: "secret-two"},
+				},
+			},
+		}
+
+		requests := m.Map(handler.MapObject{
+			Object: mr,
+		})
+		Expect(requests).To(ConsistOf(
+			reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      mr.Spec.SecretRefs[0].Name,
+				Namespace: mr.Namespace,
+			}},
+			reconcile.Request{NamespacedName: types.NamespacedName{
+				Name:      mr.Spec.SecretRefs[1].Name,
+				Namespace: mr.Namespace,
+			}},
+		))
+	})
+})

--- a/pkg/predicate/has_finalizer.go
+++ b/pkg/predicate/has_finalizer.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// HasFinalizer returns a predicate that detects if the object has the given finalizer
+// This is used to not requeue all secrets in the cluster (which might be quite a lot),
+// but only requeue secrets from create/update events with the controller's finalizer.
+// This is to ensure, that we properly remove the finalizer in case we missed an important
+// update event for a ManagedResource.
+func HasFinalizer(finalizer string) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			// Create event is emitted on start-up, when the cache is populated from a complete list call for the first time.
+			// We should enqueue all secrets, which have the controller's finalizer in order to remove it in case we missed
+			// an important update event to a ManagedResource during downtime.
+			if e.Meta == nil {
+				log.Error(nil, "Create event has no object meta", "event", e)
+				return false
+			}
+
+			return metaHasFinalizer(e.Meta, finalizer)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// We only need to check MetaNew. If the finalizer was in MetaOld and is not in MetaNew, it is already
+			// removed and we don't need to reconcile the secret.
+			if e.MetaNew == nil {
+				log.Error(nil, "Update event has no new object meta", "event", e)
+				return false
+			}
+
+			return metaHasFinalizer(e.MetaNew, finalizer)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			// If the secret is already deleted, all finalizers are already gone and we don't need to reconcile it.
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+func metaHasFinalizer(meta metav1.Object, finalizer string) bool {
+	return sets.NewString(meta.GetFinalizers()...).Has(finalizer)
+}

--- a/pkg/predicate/has_finalizer_test.go
+++ b/pkg/predicate/has_finalizer_test.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate_test
+
+import (
+	"github.com/gardener/gardener-resource-manager/pkg/controller/managedresources"
+	managerpredicate "github.com/gardener/gardener-resource-manager/pkg/predicate"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ = Describe("#HasFinalizer", func() {
+	var (
+		secret    *corev1.Secret
+		finalizer string
+		predicate predicate.Predicate
+	)
+
+	BeforeEach(func() {
+		finalizer = managedresources.NewClassFilter("foo").FinalizerName()
+		predicate = managerpredicate.HasFinalizer(finalizer)
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Finalizers: nil,
+			},
+		}
+	})
+
+	Context("#Create", func() {
+		It("should not match on create event (no metadata)", func() {
+			Expect(predicate.Create(event.CreateEvent{
+				Meta:   nil,
+				Object: secret,
+			})).To(BeFalse())
+		})
+
+		It("should not match on create event (no finalizer)", func() {
+			Expect(predicate.Create(event.CreateEvent{
+				Meta:   &secret.ObjectMeta,
+				Object: secret,
+			})).To(BeFalse())
+		})
+
+		It("should not match on create event (different finalizer)", func() {
+			secret.Finalizers = []string{"other"}
+
+			Expect(predicate.Create(event.CreateEvent{
+				Meta:   &secret.ObjectMeta,
+				Object: secret,
+			})).To(BeFalse())
+		})
+
+		It("should match on create event (correct finalizer)", func() {
+			secret.Finalizers = []string{finalizer}
+
+			Expect(predicate.Create(event.CreateEvent{
+				Meta:   &secret.ObjectMeta,
+				Object: secret,
+			})).To(BeTrue())
+		})
+	})
+
+	Context("#Update", func() {
+		It("should not match on update event (no metadata)", func() {
+			Expect(predicate.Update(event.UpdateEvent{
+				MetaOld:   &secret.ObjectMeta,
+				ObjectOld: secret,
+				MetaNew:   &secret.ObjectMeta,
+				ObjectNew: secret,
+			})).To(BeFalse())
+		})
+
+		It("should not match on update event (no finalizer)", func() {
+			Expect(predicate.Update(event.UpdateEvent{
+				MetaOld:   nil,
+				ObjectOld: secret,
+				MetaNew:   nil,
+				ObjectNew: secret,
+			})).To(BeFalse())
+		})
+
+		It("should not match on update event (different finalizer)", func() {
+			secret.Finalizers = []string{"other"}
+
+			Expect(predicate.Update(event.UpdateEvent{
+				MetaOld:   &secret.ObjectMeta,
+				ObjectOld: secret,
+				MetaNew:   &secret.ObjectMeta,
+				ObjectNew: secret,
+			})).To(BeFalse())
+		})
+
+		It("should not match on update event (correct finalizer removed)", func() {
+			secretCopy := *secret
+			secret.Finalizers = []string{finalizer}
+
+			Expect(predicate.Update(event.UpdateEvent{
+				MetaOld:   &secret.ObjectMeta,
+				ObjectOld: secret,
+				MetaNew:   &secretCopy.ObjectMeta,
+				ObjectNew: &secretCopy,
+			})).To(BeFalse())
+		})
+
+		It("should match on update event (correct finalizer added)", func() {
+			secretCopy := *secret
+			secret.Finalizers = []string{finalizer}
+
+			Expect(predicate.Update(event.UpdateEvent{
+				MetaOld:   &secretCopy.ObjectMeta,
+				ObjectOld: &secretCopy,
+				MetaNew:   &secret.ObjectMeta,
+				ObjectNew: secret,
+			})).To(BeTrue())
+		})
+
+		It("should match on update event (correct finalizer)", func() {
+			secret.Finalizers = []string{finalizer}
+
+			Expect(predicate.Update(event.UpdateEvent{
+				MetaOld:   &secret.ObjectMeta,
+				ObjectOld: secret,
+				MetaNew:   &secret.ObjectMeta,
+				ObjectNew: secret,
+			})).To(BeTrue())
+		})
+	})
+
+	Describe("#Delete", func() {
+		It("should not match on delete event", func() {
+			Expect(predicate.Delete(event.DeleteEvent{
+				Meta:   &secret.ObjectMeta,
+				Object: secret,
+			})).To(BeFalse())
+		})
+	})
+
+	Describe("#Generic", func() {
+		It("should not match on generic event", func() {
+			Expect(predicate.Generic(event.GenericEvent{
+				Meta:   &secret.ObjectMeta,
+				Object: secret,
+			})).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new controller for secrets, that is only responsible for adding/removing `grm`'s finalizer to/from secrets referenced by ManagedResources.
It watches ManagedResources and enqueues all secrets on a generation change, that are/were referenced by the ManagedResource. It additionally enqueues secrets with its finalizer on create and update to remove its finalizer if it missed an important update event during a downtime.

So now, grm properly removes its finalizer from secrets that are not referenced by a ManagedResource anymore.

**Which issue(s) this PR fixes**:
Fixes #52

**Special notes for your reviewer**:
Tests will fail because of changes introduced by #46, but should run green after rebasing on #53
✅ test-wise depends on #53

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`gardener-resource-manager` now properly removes its finalizer from secrets, that are not referenced by a `ManagedResource` anymore.
```
```noteworthy operator
Please ensure, that `gardener-resource-manager` has the required permissions to also update secrets now.
```
