### PR TITLE
Prevent errors to be logged multiple times

### DIFF
--- a/pkg/controller/managedresources/health/health_controller.go
+++ b/pkg/controller/managedresources/health/health_controller.go
@@ -58,8 +58,7 @@ func (r *HealthReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			log.Info("Stopping health checks for ManagedResource, as it has been deleted")
 			return reconcile.Result{}, nil
 		}
-		log.Error(err, "Could not fetch Managedresource")
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("could not fetch ManagedResource: %+v", err)
 	}
 
 	// Check responsibility
@@ -74,8 +73,7 @@ func (r *HealthReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	if !mr.DeletionTimestamp.IsZero() {
 		conditionResourcesHealthy = resourcesv1alpha1helper.UpdatedCondition(conditionResourcesHealthy, resourcesv1alpha1.ConditionFalse, resourcesv1alpha1.ConditionDeletionPending, "The resources are currently being deleted.")
 		if err := tryUpdateManagedResourceCondition(r.ctx, r.client, mr, conditionResourcesHealthy); err != nil {
-			log.Error(err, "Could not update the ManagedResource status")
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("could not update the ManagedResource status: %+v ", err)
 		}
 
 		log.Info("Stopping health checks for ManagedResource, as it has been deleted (deletionTimestamp is set)")
@@ -118,8 +116,7 @@ func (r *HealthReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 				conditionResourcesHealthy = resourcesv1alpha1helper.UpdatedCondition(conditionResourcesHealthy, resourcesv1alpha1.ConditionFalse, reason, message)
 				if err := tryUpdateManagedResourceCondition(r.ctx, r.client, mr, conditionResourcesHealthy); err != nil {
-					log.Error(err, "Could not update the ManagedResource status")
-					return ctrl.Result{}, err
+					return ctrl.Result{}, fmt.Errorf("could not update the ManagedResource status: %+v ", err)
 				}
 
 				return ctrl.Result{RequeueAfter: r.syncPeriod}, nil // We do not want to run in the exponential backoff for the condition check.
@@ -136,8 +133,7 @@ func (r *HealthReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 			conditionResourcesHealthy = resourcesv1alpha1helper.UpdatedCondition(conditionResourcesHealthy, resourcesv1alpha1.ConditionFalse, reason, message)
 			if err := tryUpdateManagedResourceCondition(r.ctx, r.client, mr, conditionResourcesHealthy); err != nil {
-				log.Error(err, "Could not update the ManagedResource status")
-				return ctrl.Result{}, err
+				return ctrl.Result{}, fmt.Errorf("could not update the ManagedResource status: %+v ", err)
 			}
 
 			return ctrl.Result{RequeueAfter: r.syncPeriod}, nil // We do not want to run in the exponential backoff for the condition check.
@@ -146,8 +142,7 @@ func (r *HealthReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	conditionResourcesHealthy = resourcesv1alpha1helper.UpdatedCondition(conditionResourcesHealthy, resourcesv1alpha1.ConditionTrue, "ResourcesHealthy", "All resources are healthy.")
 	if err := tryUpdateManagedResourceCondition(r.ctx, r.client, mr, conditionResourcesHealthy); err != nil {
-		log.Error(err, "Could not update the ManagedResource status")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("could not update the ManagedResource status: %+v ", err)
 	}
 
 	log.Info("Finished ManagedResource health checks")

--- a/pkg/controller/managedresources/secret_controller_test.go
+++ b/pkg/controller/managedresources/secret_controller_test.go
@@ -358,9 +358,7 @@ var _ = Describe("SecretReconciler", func() {
 			}))
 		})
 
-		It("should fail if secret update fails", func() {
-			fakeErr := fmt.Errorf("fake")
-
+		It("should requeue if secret update fails", func() {
 			secret.Finalizers = []string{filter.FinalizerName()}
 
 			mrs := []resourcesv1alpha1.ManagedResource{{
@@ -384,11 +382,11 @@ var _ = Describe("SecretReconciler", func() {
 				})
 			c.EXPECT().Update(nil, gomock.AssignableToTypeOf(secret)).
 				DoAndReturn(func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
-					return fakeErr
+					return fmt.Errorf("fake")
 				})
 
 			res, err := r.Reconcile(secretReq)
-			Expect(err).To(MatchError(ContainSubstring("fake")))
+			Expect(err).To(BeNil())
 			Expect(res).To(Equal(reconcile.Result{
 				RequeueAfter: 5 * time.Second,
 			}))


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent errors to be logged multiple times.

**Which issue(s) this PR fixes**:
Ref gardener/gardener#2325

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
