### PR TITLE
Add APIService to target scheme

### DIFF
--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -36,8 +36,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -48,6 +47,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
+	apiregistrationinstall "k8s.io/kube-aggregator/pkg/apis/apiregistration/install"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -123,8 +123,8 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 
 			targetScheme := runtime.NewScheme()
 			utilruntime.Must(scheme.AddToScheme(targetScheme)) // add most of the standard k8s APIs
-			utilruntime.Must(apiextensionsv1beta1.AddToScheme(targetScheme))
-			utilruntime.Must(apiextensionsv1.AddToScheme(targetScheme))
+			apiextensionsinstall.Install(targetScheme)
+			apiregistrationinstall.Install(targetScheme)
 			utilruntime.Must(hvpav1alpha1.AddToScheme(targetScheme))
 
 			targetConfig, err := getTargetConfig(targetKubeconfigPath)

--- a/go.mod
+++ b/go.mod
@@ -13,21 +13,23 @@ require (
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.13.0
-	k8s.io/api v0.17.0 // kubernetes-1.16.0
-	k8s.io/apiextensions-apiserver v0.17.0 // kubernetes-1.16.0
-	k8s.io/apimachinery v0.17.0 // kubernetes-1.16.0
+	k8s.io/api v0.17.0
+	k8s.io/apiextensions-apiserver v0.17.0
+	k8s.io/apimachinery v0.17.0
 	k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e
-	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible // kubernetes-1.16.0
-	k8s.io/code-generator v0.17.0 // kubernetes-1.16.0
+	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
+	k8s.io/code-generator v0.17.0
+	k8s.io/kube-aggregator v0.16.8
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 	k8s.io/utils v0.0.0-20200327001022-6496210b90e8
 	sigs.k8s.io/controller-runtime v0.4.0
 )
 
 replace (
-	k8s.io/api => k8s.io/api v0.16.8 // 1.16.8
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.16.8 // 1.16.8
-	k8s.io/apimachinery => k8s.io/apimachinery v0.16.8 // 1.16.8
-	k8s.io/client-go => k8s.io/client-go v0.16.8 // 1.16.8
-	k8s.io/code-generator => k8s.io/code-generator v0.16.8 // 1.16.8
+	k8s.io/api => k8s.io/api v0.16.8
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.16.8
+	k8s.io/apimachinery => k8s.io/apimachinery v0.16.8
+	k8s.io/client-go => k8s.io/client-go v0.16.8
+	k8s.io/code-generator => k8s.io/code-generator v0.16.8
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.16.8
 )

--- a/go.sum
+++ b/go.sum
@@ -828,7 +828,6 @@ k8s.io/klog v0.4.0 h1:lCJCxf/LIowc2IGS9TPjWDyXY4nOmdGdfcwwDQCOURQ=
 k8s.io/klog v0.4.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
-k8s.io/kube-aggregator v0.0.0-20191004104030-d9d5f0cc7532/go.mod h1:8sbzT4QQKDEmSCIbfqjV0sd97GpUT7A4W626sBiYJmU=
 k8s.io/kube-aggregator v0.16.8 h1:Z7+kBXA5V/SKINY9W7QBvZn/Orf5jwPAcW4cPJnNxFA=
 k8s.io/kube-aggregator v0.16.8/go.mod h1:l73g+bVdjrgDz9nrISk6AgupGbv1n+4WjTbGaXz/YvI=
 k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=

--- a/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install/install.go
+++ b/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install/install.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install
+
+import (
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// Install registers the API group and adds types to a scheme
+func Install(scheme *runtime.Scheme) {
+	utilruntime.Must(apiextensions.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
+	utilruntime.Must(scheme.SetVersionPriority(v1beta1.SchemeGroupVersion, v1.SchemeGroupVersion))
+}

--- a/vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/install/install.go
+++ b/vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/install/install.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package install
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
+	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	"k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
+)
+
+// Install registers the API group and adds types to a scheme
+func Install(scheme *runtime.Scheme) {
+	utilruntime.Must(apiregistration.AddToScheme(scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
+	utilruntime.Must(scheme.SetVersionPriority(v1.SchemeGroupVersion, v1beta1.SchemeGroupVersion))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -436,6 +436,7 @@ k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.17.0 => k8s.io/apiextensions-apiserver v0.16.8
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
+k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset
@@ -634,8 +635,9 @@ k8s.io/helm/pkg/timeconv
 k8s.io/helm/pkg/version
 # k8s.io/klog v1.0.0
 k8s.io/klog
-# k8s.io/kube-aggregator v0.16.8
+# k8s.io/kube-aggregator v0.16.8 => k8s.io/kube-aggregator v0.16.8
 k8s.io/kube-aggregator/pkg/apis/apiregistration
+k8s.io/kube-aggregator/pkg/apis/apiregistration/install
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
 k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds the `APIService` types to the target scheme, so grm can leverage the cache when health checking applied `APIService`s.

**Which issue(s) this PR fixes**:
Fixes #59 

**Special notes for your reviewer**:
/invite @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
