### PR TITLE
Configuration for whether resources should be always updated

### DIFF
--- a/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/gardener-resource-manager/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --max-concurrent-workers={{ .Values.controllers.managedResource.concurrentSyncs }}
         - --health-sync-period={{ .Values.controllers.managedResourceHealth.syncPeriod }}
         - --health-max-concurrent-workers={{ .Values.controllers.managedResourceHealth.concurrentSyncs }}
+        - --always-update={{ .Values.controllers.managedResource.alwaysUpdate }}
         {{- if .Values.targetKubeconfig }}
         - --target-kubeconfig=/etc/gardener-resource-manager/target-kubeconfig/kubeconfig.yaml
         {{- end }}

--- a/charts/gardener-resource-manager/values.yaml
+++ b/charts/gardener-resource-manager/values.yaml
@@ -10,6 +10,7 @@ controllers:
   managedResource:
     syncPeriod: 1m0s
     concurrentSyncs: 10
+    alwaysUpdate: false
   managedResourceHealth:
     syncPeriod: 1m0s
     concurrentSyncs: 10

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -82,6 +82,7 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 		kubeconfigPath             string
 		namespace                  string
 		resourceClass              string
+		alwaysUpdate               bool
 	)
 
 	cmd := &cobra.Command{
@@ -175,6 +176,7 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 						targetRESTMapper,
 						targetScheme,
 						filter,
+						alwaysUpdate,
 						syncPeriod,
 					),
 				),
@@ -330,6 +332,7 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&targetKubeconfigPath, "target-kubeconfig", "", "path to the kubeconfig for the target cluster")
 	cmd.Flags().StringVar(&namespace, "namespace", "", "namespace in which the ManagedResources should be observed (defaults to all namespaces)")
 	cmd.Flags().StringVar(&resourceClass, "resource-class", managedresources.DefaultClass, "resource class used to filter resource resources")
+	cmd.Flags().BoolVar(&alwaysUpdate, "always-update", false, "if set to false then a resource will only be updated if its desired state differs from the actual state. otherwise, an update request will be always sent.")
 
 	return cmd
 }

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -24,7 +24,7 @@ go install -mod=vendor ./vendor/github.com/golang/mock/mockgen
 # Install golangci-lint
 curl -sfL "https://install.goreleaser.com/github.com/golangci/golangci-lint.sh" | sh -s -- -b $(go env GOPATH)/bin v1.22.2
 
-curl -s "https://raw.githubusercontent.com/helm/helm/v2.13.1/scripts/get" | bash -s -- --version 'v2.13.1'
+curl -s "https://raw.githubusercontent.com/helm/helm/v2.16.9/scripts/get" | bash -s -- --version 'v2.13.1'
 
 if [[ "$(uname -s)" == *"Darwin"* ]]; then
   cat <<EOM

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -144,7 +144,7 @@ func TryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj r
 // API server, applies the given mutate func and creates or updates it afterwards. In contrast to
 // controllerutil.CreateOrUpdate it tries to create a new typed object of obj's kind (using the provided scheme)
 // to make typed Get requests in order to leverage the client's cache.
-func TypedCreateOrUpdate(ctx context.Context, c client.Client, scheme *runtime.Scheme, obj *unstructured.Unstructured, mutate func() error) error {
+func TypedCreateOrUpdate(ctx context.Context, c client.Client, scheme *runtime.Scheme, obj *unstructured.Unstructured, alwaysUpdate bool, mutate func() error) error {
 	key, err := client.ObjectKeyFromObject(obj)
 	if err != nil {
 		return err
@@ -191,7 +191,7 @@ func TypedCreateOrUpdate(ctx context.Context, c client.Client, scheme *runtime.S
 		return err
 	}
 
-	if apiequality.Semantic.DeepEqual(existing, obj) {
+	if !alwaysUpdate && apiequality.Semantic.DeepEqual(existing, obj) {
 		return nil
 	}
 

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -103,7 +103,7 @@ var _ = Describe("utils", func() {
 					c.EXPECT().Create(ctx, obj),
 				)
 
-				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+				err := TypedCreateOrUpdate(ctx, c, s, obj, false, func() error {
 					Expect(obj.Object["spec"]).To(BeNil(), "obj should not be filled, as the object does not exist yet")
 					return nil
 				})
@@ -121,7 +121,28 @@ var _ = Describe("utils", func() {
 						return nil
 					})
 
-				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+				err := TypedCreateOrUpdate(ctx, c, s, obj, false, func() error {
+					Expect(obj).To(BeSemanticallyEqualTo(currentDeploymentUnstructured), "obj should be filled with the obj's current spec")
+					return nil
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should make a typed get request and don't skip update (no changes but alwaysUpdate=false)", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, gomock.AssignableToTypeOf(&appsv1.Deployment{})).
+						DoAndReturn(func(ctx context.Context, key client.ObjectKey, o runtime.Object) error {
+							deploy, ok := o.(*appsv1.Deployment)
+							Expect(ok).To(BeTrue())
+
+							currentDeployment.DeepCopyInto(deploy)
+							return nil
+						}),
+					c.EXPECT().Update(ctx, obj),
+				)
+
+				err := TypedCreateOrUpdate(ctx, c, s, obj, true, func() error {
 					Expect(obj).To(BeSemanticallyEqualTo(currentDeploymentUnstructured), "obj should be filled with the obj's current spec")
 					return nil
 				})
@@ -142,7 +163,7 @@ var _ = Describe("utils", func() {
 					c.EXPECT().Update(ctx, obj),
 				)
 
-				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+				err := TypedCreateOrUpdate(ctx, c, s, obj, false, func() error {
 					Expect(obj).To(BeSemanticallyEqualTo(currentDeploymentUnstructured), "obj should be filled with the obj's current spec")
 
 					// mutate object
@@ -195,7 +216,7 @@ var _ = Describe("utils", func() {
 					c.EXPECT().Create(ctx, obj),
 				)
 
-				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+				err := TypedCreateOrUpdate(ctx, c, s, obj, false, func() error {
 					Expect(obj.Object["spec"]).To(BeNil(), "obj should not be filled, as the object does not exist yet")
 					return nil
 				})
@@ -213,7 +234,28 @@ var _ = Describe("utils", func() {
 						return nil
 					})
 
-				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+				err := TypedCreateOrUpdate(ctx, c, s, obj, false, func() error {
+					Expect(obj).To(BeSemanticallyEqualTo(currentVPAUnstructured), "obj should be filled with the obj's current spec")
+					return nil
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should fallback to an unstructured get request but don't skip update (no changes but alwaysUpdate=true)", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, gomock.AssignableToTypeOf(&unstructured.Unstructured{})).
+						DoAndReturn(func(ctx context.Context, key client.ObjectKey, o runtime.Object) error {
+							vpa, ok := o.(*unstructured.Unstructured)
+							Expect(ok).To(BeTrue())
+
+							currentVPAUnstructured.DeepCopyInto(vpa)
+							return nil
+						}),
+					c.EXPECT().Update(ctx, obj),
+				)
+
+				err := TypedCreateOrUpdate(ctx, c, s, obj, true, func() error {
 					Expect(obj).To(BeSemanticallyEqualTo(currentVPAUnstructured), "obj should be filled with the obj's current spec")
 					return nil
 				})
@@ -234,7 +276,7 @@ var _ = Describe("utils", func() {
 					c.EXPECT().Update(ctx, obj),
 				)
 
-				err := TypedCreateOrUpdate(ctx, c, s, obj, func() error {
+				err := TypedCreateOrUpdate(ctx, c, s, obj, false, func() error {
 					Expect(obj).To(BeSemanticallyEqualTo(currentVPAUnstructured), "obj should be filled with the obj's current spec")
 
 					// mutate object


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR introduces a new command line parameter `--always-update` which defaults to `false`. If set to `true` it will always send a `PUT` request for managed resources even if it detects that their desired state does not differ from their actual state in the system. This is 

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/gardener-extension-provider-aws/issues/134

**Special notes for your reviewer**:
/invite @tim-ebert 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
The new `--always-update` command line parameter (default: `false`) allows to configure whether to always send a `PUT` request for managed resources regardless of whether their desired state differs from their actual state.
```
