### PR TITLE
Allow to configure leader election settings

### DIFF
--- a/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/gardener-resource-manager/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         - /gardener-resource-manager
         - --leader-election={{ .Values.leaderElection.enabled }}
         - --leader-election-namespace={{ .Release.Namespace }}
+        - --leader-election-lease-duration={{ .Values.leaderElection.leaseDuration }}
+        - --leader-election-renew-deadline={{ .Values.leaderElection.renewDeadline }}
+        - --leader-election-retry-period={{ .Values.leaderElection.retryPeriod }}
         {{- if .Values.controllers.cacheResyncPeriod }}
         - --cache-resync-period={{ .Values.controllers.cacheResyncPeriod }}
         {{- end }}

--- a/charts/gardener-resource-manager/values.yaml
+++ b/charts/gardener-resource-manager/values.yaml
@@ -17,6 +17,9 @@ controllers:
 
 leaderElection:
   enabled: true
+  leaseDuration: 15s
+  renewDeadline: 10s
+  retryPeriod: 2s
 
 # targetKubeconfig: |
 #   apiVersion: v1

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -69,20 +69,27 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 	entryLog := log.WithName("entrypoint")
 
 	var (
-		leaderElection             bool
-		leaderElectionNamespace    string
-		cacheResyncPeriod          time.Duration
-		targetCacheResyncPeriod    time.Duration
-		syncPeriod                 time.Duration
+		leaderElection              bool
+		leaderElectionNamespace     string
+		leaderElectionLeaseDuration time.Duration
+		leaderElectionRenewDeadline time.Duration
+		leaderElectionRetryPeriod   time.Duration
+
+		cacheResyncPeriod       time.Duration
+		targetCacheResyncPeriod time.Duration
+		syncPeriod              time.Duration
+		healthSyncPeriod        time.Duration
+
 		maxConcurrentWorkers       int
 		secretMaxConcurrentWorkers int
-		healthSyncPeriod           time.Duration
 		healthMaxConcurrentWorkers int
-		targetKubeconfigPath       string
-		kubeconfigPath             string
-		namespace                  string
-		resourceClass              string
-		alwaysUpdate               bool
+
+		targetKubeconfigPath string
+		kubeconfigPath       string
+
+		namespace     string
+		resourceClass string
+		alwaysUpdate  bool
 	)
 
 	cmd := &cobra.Command{
@@ -113,6 +120,9 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 				LeaderElection:          leaderElection,
 				LeaderElectionID:        "gardener-resource-manager",
 				LeaderElectionNamespace: leaderElectionNamespace,
+				LeaseDuration:           &leaderElectionLeaseDuration,
+				RenewDeadline:           &leaderElectionRenewDeadline,
+				RetryPeriod:             &leaderElectionRetryPeriod,
 				SyncPeriod:              &cacheResyncPeriod,
 				Namespace:               namespace,
 			})
@@ -321,6 +331,9 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 
 	cmd.Flags().BoolVar(&leaderElection, "leader-election", true, "enable or disable leader election")
 	cmd.Flags().StringVar(&leaderElectionNamespace, "leader-election-namespace", "", "namespace for leader election")
+	cmd.Flags().DurationVar(&leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second, "lease duration for leader election")
+	cmd.Flags().DurationVar(&leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second, "renew deadline for leader election")
+	cmd.Flags().DurationVar(&leaderElectionRetryPeriod, "leader-election-retry-period", 2*time.Second, "retry period for leader election")
 	cmd.Flags().DurationVar(&cacheResyncPeriod, "cache-resync-period", 24*time.Hour, "duration how often the controller's cache is resynced")
 	cmd.Flags().DurationVar(&syncPeriod, "sync-period", time.Minute, "duration how often existing resources should be synced")
 	cmd.Flags().DurationVar(&targetCacheResyncPeriod, "target-cache-resync-period", 24*time.Hour, "duration how often the controller's cache for the target cluster is resynced")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area robustness cost networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:
With this PR we allow to configure the leader election settings for the gardener-resource-manager to allow users to configure them as appropriate for their use-cases.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#1953 

**Special notes for your reviewer**:
/invite @timebertt @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
It is now possible to specify the leader election settings via the following command line parameters: `--leader-election-lease-duration` (default: `15s`), `--leader-election-renew-deadline` (default: `10s`), `--leader-election-retry-period` (default: `2s`).
```
