### PR TITLE
Allow to keep single objects in the system during deletion

### DIFF
--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -26,6 +26,10 @@ const (
 	// DeleteOnInvalidUpdate is a constant for an annotation on a resource managed by a ManagedResource. If set to
 	// true then the controller will delete the object in case it faces an "Invalid" response during an update operation.
 	DeleteOnInvalidUpdate = "resources.gardener.cloud/delete-on-invalid-update"
+	// KeepObject is a constant for an annotation on a resource managed by a ManagedResource. If set to
+	// true then the controller will not delete the object in case it is removed from the ManagedResource or the
+	// ManagedResource itself is deleted.
+	KeepObject = "resources.gardener.cloud/keep-object"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/managedresources/controller.go
+++ b/pkg/controller/managedresources/controller.go
@@ -566,6 +566,10 @@ func deleteOnInvalidUpdate(meta metav1.Object) bool {
 	return annotationExistsAndValueTrue(meta, resourcesv1alpha1.DeleteOnInvalidUpdate)
 }
 
+func keepObject(meta metav1.Object) bool {
+	return annotationExistsAndValueTrue(meta, resourcesv1alpha1.KeepObject)
+}
+
 func annotationExistsAndValueTrue(meta metav1.Object, key string) bool {
 	annotations := meta.GetAnnotations()
 	if annotations == nil {
@@ -617,6 +621,12 @@ func (r *Reconciler) cleanOldResources(index *ObjectIndex, mr *resourcesv1alpha1
 					}
 
 					// resource already deleted, nothing to do here
+					results <- &output{resource, false, nil}
+					return
+				}
+
+				if keepObject(obj) {
+					r.log.Info("Keeping object in the system as "+resourcesv1alpha1.KeepObject+" annotation found", "resource", unstructuredToString(obj))
 					results <- &output{resource, false, nil}
 					return
 				}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds support for a new `resources.gardener.cloud/keep-object` annotation that can be put to resources managed by the `ManagedResource` in order to prevent that they get deleted in case they get removed from the `ManagedResource`, or in case the `ManagedResource` itself is deleted.
Earlier, it was only possible to configure this for the whole set of resources by setting `.spec.keepObjects=true`.

**Special notes for your reviewer**:
/invite @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy developer
The new `resources.gardener.cloud/keep-object` annotation can be used on resources managed by `ManagedResource` objects in order to keep them in the system in case they get removed from the `ManagedResource` or the `ManagedResource` itself is being deleted.
```
