### PR TITLE
add fallback option for a manifest in a managed resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ TODO
 # Packr generated files
 *-packr.go
 
+/cmd/gardener-resource-manager/controller
 /controller

--- a/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/gardener-resource-manager/templates/deployment.yaml
@@ -38,6 +38,9 @@ spec:
         {{- if .Values.controllers.cacheResyncPeriod }}
         - --cache-resync-period={{ .Values.controllers.cacheResyncPeriod }}
         {{- end }}
+        {{- if .Values.controllers.managedResource.clusterID }}
+        - --cluster-id={{ .Values.controllers.managedResource.clusterID }}
+        {{- end }}
         - --sync-period={{ .Values.controllers.managedResource.syncPeriod }}
         - --max-concurrent-workers={{ .Values.controllers.managedResource.concurrentSyncs }}
         - --health-sync-period={{ .Values.controllers.managedResourceHealth.syncPeriod }}

--- a/charts/gardener-resource-manager/values.yaml
+++ b/charts/gardener-resource-manager/values.yaml
@@ -11,6 +11,7 @@ controllers:
     syncPeriod: 1m0s
     concurrentSyncs: 10
     alwaysUpdate: false
+    # clusterID: ""
   managedResourceHealth:
     syncPeriod: 1m0s
     concurrentSyncs: 10

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -347,7 +347,7 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&targetKubeconfigPath, "target-kubeconfig", "", "path to the kubeconfig for the target cluster")
 	cmd.Flags().StringVar(&namespace, "namespace", "", "namespace in which the ManagedResources should be observed (defaults to all namespaces)")
 	cmd.Flags().StringVar(&resourceClass, "resource-class", managedresources.DefaultClass, "resource class used to filter resource resources")
-	cmd.Flags().StringVar(&clusterID, "cluster-id", "", "optional cluster id for source cluster")
+	cmd.Flags().StringVar(&clusterID, "cluster-id", managedresources.IdentifyByDefault, "optional cluster id for source cluster")
 	cmd.Flags().BoolVar(&alwaysUpdate, "always-update", false, "if set to false then a resource will only be updated if its desired state differs from the actual state. otherwise, an update request will be always sent.")
 
 	return cmd

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -86,6 +86,7 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 
 		targetKubeconfigPath string
 		kubeconfigPath       string
+		clusterID            string
 
 		namespace     string
 		resourceClass string
@@ -188,6 +189,7 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 						filter,
 						alwaysUpdate,
 						syncPeriod,
+						clusterID,
 					),
 				),
 			})
@@ -345,6 +347,7 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&targetKubeconfigPath, "target-kubeconfig", "", "path to the kubeconfig for the target cluster")
 	cmd.Flags().StringVar(&namespace, "namespace", "", "namespace in which the ManagedResources should be observed (defaults to all namespaces)")
 	cmd.Flags().StringVar(&resourceClass, "resource-class", managedresources.DefaultClass, "resource class used to filter resource resources")
+	cmd.Flags().StringVar(&clusterID, "cluster-id", "", "optional cluster id for source cluster")
 	cmd.Flags().BoolVar(&alwaysUpdate, "always-update", false, "if set to false then a resource will only be updated if its desired state differs from the actual state. otherwise, an update request will be always sent.")
 
 	return cmd

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -99,12 +99,19 @@ type ManagedResourceStatus struct {
 	Resources []ObjectReference `json:"resources,omitempty"`
 }
 
+// ObjectReference is used to store reconcilation relevant information about the
+// last deployed version of objects managed by a ManagedResource
 type ObjectReference struct {
 	corev1.ObjectReference `json:",inline"`
 	// Labels is a map of labels that were used during last update of the resource.
 	Labels map[string]string `json:"labels,omitempty"`
 	// Annotations is a map of annotations that were used during last update of the resource.
 	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// GetAnnotations return the actual annotations and is used as implementation for the AnnotationProvider interface
+func (o ObjectReference) GetAnnotations() map[string]string {
+	return o.Annotations
 }
 
 // ConditionType is the type of a condition.

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -30,6 +30,10 @@ const (
 	// true then the controller will not delete the object in case it is removed from the ManagedResource or the
 	// ManagedResource itself is deleted.
 	KeepObject = "resources.gardener.cloud/keep-object"
+	// Fallback is an annotation that tells the resource manager to ignore the resource if it is
+	// maintained by somebody else. This is identified by looking at the at the description annotation implicitly
+	// added by the resource manager
+	Fallback = "resources.gardener.cloud/fallback"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/managedresources/controller.go
+++ b/pkg/controller/managedresources/controller.go
@@ -101,7 +101,7 @@ type Reconciler struct {
 	class        *ClassFilter
 	alwaysUpdate bool
 	syncPeriod   time.Duration
-	cluster      string
+	clusterID    string
 }
 
 // NewReconciler creates a new reconciler with the given target client.
@@ -160,14 +160,14 @@ func (r *Reconciler) determineClusterIdentity(c client.Client, force bool) (stri
 
 func (r *Reconciler) origin(mr *resourcesv1alpha1.ManagedResource) string {
 	var err error
-	if r.cluster == IdentityByCluster || r.cluster == IdentifyByDefault {
-		r.cluster, err = r.determineClusterIdentity(r.client, r.cluster == IdentityByCluster)
+	if r.clusterID == IdentityByCluster || r.clusterID == IdentifyByDefault {
+		r.clusterID, err = r.determineClusterIdentity(r.client, r.clusterID == IdentityByCluster)
 		if err != nil {
 			panic(err)
 		}
 	}
-	if r.cluster != "" {
-		return r.cluster + ":" + mr.Namespace + "/" + mr.Name
+	if r.clusterID != "" {
+		return r.clusterID + ":" + mr.Namespace + "/" + mr.Name
 	}
 	return mr.Namespace + "/" + mr.Name
 }
@@ -661,7 +661,6 @@ func ignore(origin string, meta AnnotationProvider, curmeta metav1.Object) bool 
 	if annotationExistsAndValueTrue(meta, resourcesv1alpha1.Ignore) {
 		return true
 	}
-
 	return ignoreFallback(origin, meta, curmeta)
 }
 

--- a/pkg/controller/managedresources/merger.go
+++ b/pkg/controller/managedresources/merger.go
@@ -29,12 +29,13 @@ const (
 	descriptionAnnotation     = "resources.gardener.cloud/description"
 	descriptionAnnotationText = `DO NOT EDIT - This resource is managed by gardener-resource-manager.
 Any modifications are discarded and the resource is returned to the original state.`
+	originAnnotation = "resources.gardener.cloud/origin"
 )
 
 // merge merges the values of the `desired` object into the `current` object while preserving `current`'s important
 // metadata (like resourceVersion and finalizers), status and selected spec fields of the respective kind (e.g.
 // .spec.selector of a Job).
-func merge(desired, current *unstructured.Unstructured, forceOverwriteLabels bool, existingLabels map[string]string, forceOverwriteAnnotations bool, existingAnnotations map[string]string, preserveReplicas, preserveResources bool) error {
+func merge(origin string, desired, current *unstructured.Unstructured, forceOverwriteLabels bool, existingLabels map[string]string, forceOverwriteAnnotations bool, existingAnnotations map[string]string, preserveReplicas, preserveResources bool) error {
 	// save copy of current object before merging
 	oldObject := current.DeepCopy()
 
@@ -71,6 +72,7 @@ func merge(desired, current *unstructured.Unstructured, forceOverwriteLabels boo
 	}
 
 	ann[descriptionAnnotation] = descriptionAnnotationText
+	ann[originAnnotation] = origin
 	newObject.SetAnnotations(ann)
 
 	// keep status of old object if it is set and not empty

--- a/pkg/controller/managedresources/merger_test.go
+++ b/pkg/controller/managedresources/merger_test.go
@@ -32,6 +32,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var origin = "origin"
+
 var _ = Describe("merger", func() {
 
 	Describe("#merge", func() {
@@ -79,7 +81,7 @@ var _ = Describe("merger", func() {
 			expected := current.DeepCopy()
 			addDescriptionAnnotations(expected)
 
-			Expect(merge(desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["metadata"]).To(Equal(expected.Object["metadata"]))
 		})
 
@@ -90,7 +92,7 @@ var _ = Describe("merger", func() {
 
 			expected := desired.DeepCopy()
 
-			Expect(merge(desired, current, true, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, true, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -105,7 +107,7 @@ var _ = Describe("merger", func() {
 				"other": "baz",
 			})
 
-			Expect(merge(desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -119,7 +121,7 @@ var _ = Describe("merger", func() {
 				"other": "baz",
 			})
 
-			Expect(merge(desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -134,7 +136,7 @@ var _ = Describe("merger", func() {
 				"other": "baz",
 			})
 
-			Expect(merge(desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -146,7 +148,7 @@ var _ = Describe("merger", func() {
 			expected := desired.DeepCopy()
 			addDescriptionAnnotations(expected)
 
-			Expect(merge(desired, current, false, nil, true, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, true, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -162,7 +164,7 @@ var _ = Describe("merger", func() {
 			})
 			addDescriptionAnnotations(expected)
 
-			Expect(merge(desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -177,7 +179,7 @@ var _ = Describe("merger", func() {
 			})
 			addDescriptionAnnotations(expected)
 
-			Expect(merge(desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -193,7 +195,7 @@ var _ = Describe("merger", func() {
 			})
 			addDescriptionAnnotations(expected)
 
-			Expect(merge(desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -207,7 +209,7 @@ var _ = Describe("merger", func() {
 
 			expected := current.DeepCopy()
 
-			Expect(merge(desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(Equal(expected.Object["status"]))
 		})
 
@@ -218,7 +220,7 @@ var _ = Describe("merger", func() {
 
 			current.Object["status"] = map[string]interface{}{}
 
-			Expect(merge(desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(BeNil())
 		})
 
@@ -229,7 +231,7 @@ var _ = Describe("merger", func() {
 
 			delete(current.Object, "status")
 
-			Expect(merge(desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(BeNil())
 		})
 
@@ -240,12 +242,12 @@ var _ = Describe("merger", func() {
 			})
 
 			It("when forceOverrideAnnotation is false", func() {
-				Expect(merge(desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+				Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
 			})
 			It("when forceOverrideAnnotation is false and old annotations exist", func() {
 				desired.SetAnnotations(map[string]string{"goo": "boo"})
 				current.SetAnnotations(map[string]string{"foo": "bar"})
-				Expect(merge(desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+				Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
 
 				Expect(current.GetAnnotations()).To(HaveKeyWithValue("goo", "boo"))
 				Expect(current.GetAnnotations()).To(HaveKeyWithValue("foo", "bar"))
@@ -253,7 +255,7 @@ var _ = Describe("merger", func() {
 
 			It("when forceOverrideAnnotation is true", func() {
 				desired.SetAnnotations(map[string]string{"goo": "boo"})
-				Expect(merge(desired, current, false, nil, true, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+				Expect(merge(origin, desired, current, false, nil, true, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
 				Expect(current.GetAnnotations()).To(HaveKeyWithValue("goo", "boo"))
 			})
 		})
@@ -855,6 +857,7 @@ func addDescriptionAnnotations(obj *unstructured.Unstructured) {
 		ann = make(map[string]string, 1)
 	}
 	ann[descriptionAnnotation] = descriptionAnnotationText
+	ann[originAnnotation] = origin
 
 	obj.SetAnnotations(ann)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->

/area robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:

This PR adds the support for a new deployment mode of resources in a managed resource (Fallback). If this mode is selected, the
resource manager normally reconciles (creates, updates, restores) the object, as long as it is still marked to be maintained by the resource manager. If this maker annotation (this usual description annotation implicitly added by the GRM) disappears, the GRM just ignores this object, als long as it exists and does not feature this annotation again.

This mode can be used to ensure, that an objects exists in a cluster and update it accordingly if it is added by this managed resource. If it is already existent and/or managed by somebody else, this version takes precedence and the version described by the managed resource is ignored.

Additionally it adds an origin annotation describing the manages resource object originating a managed object in a cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
New `fallback` deployment mode for objects in a managed resource. Such object will only be maintained
if they do not already exit or are managed by another tool.
```

To be discussed. The is-managed check could be improved to check for the originating managed resource, which is added by an additional annotation, also. This would allow potentially using multiple managed resources, where only one has no Fallback mode.  But in this case the migration must be carefully planned.