### PR TITLE
Add health endpoint for a liveness probe

### DIFF
--- a/charts/gardener-resource-manager/templates/deployment.yaml
+++ b/charts/gardener-resource-manager/templates/deployment.yaml
@@ -46,9 +46,30 @@ spec:
         {{- if .Values.targetKubeconfig }}
         - --target-kubeconfig=/etc/gardener-resource-manager/target-kubeconfig/kubeconfig.yaml
         {{- end }}
+        {{- if .Values.metricsPort }}
+        - --metrics-bind-address=":{{ .Values.metricsPort }}"
+        {{- end }}
+        {{- if .Values.healthPort }}
+        - --health-bind-address=":{{ .Values.healthPort }}"
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | nindent 12 }}
 {{- if .Values.targetKubeconfig }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.healthPort }}
+            scheme: HTTP
+          initialDelaySeconds: 30
+          failureThreshold: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.metricsPort }}
+        - name: health
+          containerPort: {{ .Values.healthPort }}
         volumeMounts:
         - name: target-kubeconfig
           mountPath: /etc/gardener-resource-manager/target-kubeconfig

--- a/charts/gardener-resource-manager/templates/service.yaml
+++ b/charts/gardener-resource-manager/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gardener-resource-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: gardener-resource-manager
+    helm.sh/chart: gardener-resource-manager
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: {{ .Values.metricsPort }}
+    protocol: TCP
+  - name: health
+    port: {{ .Values.healthPort }}
+    protocol: TCP
+  selector:
+    app.kubernetes.io/name: gardener-resource-manager
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/gardener-resource-manager/values.yaml
+++ b/charts/gardener-resource-manager/values.yaml
@@ -5,6 +5,9 @@ image:
 
 resources: {}
 
+metricsPort: 8080
+healthPort: 8081
+
 controllers:
 # cacheResyncPeriod: 24h0m0s
   managedResource:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity robustness quality
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR adds a health check that is exposed on the `/healthz` endpoint on port `8081` by default.

**Which issue(s) this PR fixes**:
Fixes #79

**Special notes for your reviewer**:
✅ Depends on #80

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The gardener-resource-manager does now feature a `/healthz` endpoint that can be used as part of a liveness probe configuration. It listens on port `8081` by default (configurable via the `--health-bind-address` flag).
```
