### PR TITLE
Fix CRD health checks due to conversion errors

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -22,7 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -73,18 +73,18 @@ func CheckManagedResourceHealthy(mr *v1alpha1.ManagedResource) error {
 }
 
 var (
-	trueCrdConditionTypes = []apiextensionsv1beta1.CustomResourceDefinitionConditionType{
-		apiextensionsv1beta1.NamesAccepted, apiextensionsv1beta1.Established,
+	trueCrdConditionTypes = []apiextensionsv1.CustomResourceDefinitionConditionType{
+		apiextensionsv1.NamesAccepted, apiextensionsv1.Established,
 	}
-	falseOptionalCrdConditionTypes = []apiextensionsv1beta1.CustomResourceDefinitionConditionType{
-		apiextensionsv1beta1.Terminating,
+	falseOptionalCrdConditionTypes = []apiextensionsv1.CustomResourceDefinitionConditionType{
+		apiextensionsv1.Terminating,
 	}
 )
 
 // CheckCustomResourceDefinition checks whether the given CustomResourceDefinition is healthy.
 // A CRD is considered healthy if its `NamesAccepted` and `Established` conditions are with status `True`
 // and its `Terminating` condition is missing or has status `False`.
-func CheckCustomResourceDefinition(crd *apiextensionsv1beta1.CustomResourceDefinition) error {
+func CheckCustomResourceDefinition(crd *apiextensionsv1.CustomResourceDefinition) error {
 	for _, trueConditionType := range trueCrdConditionTypes {
 		conditionType := string(trueConditionType)
 		condition := getCustomResourceDefinitionCondition(crd.Status.Conditions, trueConditionType)
@@ -288,7 +288,7 @@ func daemonSetMaxUnavailable(daemonSet *appsv1.DaemonSet) int32 {
 	return int32(maxUnavailable)
 }
 
-func getCustomResourceDefinitionCondition(conditions []apiextensionsv1beta1.CustomResourceDefinitionCondition, conditionType apiextensionsv1beta1.CustomResourceDefinitionConditionType) *apiextensionsv1beta1.CustomResourceDefinitionCondition {
+func getCustomResourceDefinitionCondition(conditions []apiextensionsv1.CustomResourceDefinitionCondition, conditionType apiextensionsv1.CustomResourceDefinitionConditionType) *apiextensionsv1.CustomResourceDefinitionCondition {
 	for _, condition := range conditions {
 		if condition.Type == conditionType {
 			return &condition

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onsi/gomega/types"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -39,52 +39,52 @@ func TestHealth(t *testing.T) {
 var _ = Describe("health", func() {
 	Context("CheckCustomResourceDefinition", func() {
 		DescribeTable("crds",
-			func(crd *apiextensionsv1beta1.CustomResourceDefinition, matcher types.GomegaMatcher) {
+			func(crd *apiextensionsv1.CustomResourceDefinition, matcher types.GomegaMatcher) {
 				err := health.CheckCustomResourceDefinition(crd)
 				Expect(err).To(matcher)
 			},
-			Entry("terminating", &apiextensionsv1beta1.CustomResourceDefinition{
-				Status: apiextensionsv1beta1.CustomResourceDefinitionStatus{
-					Conditions: []apiextensionsv1beta1.CustomResourceDefinitionCondition{
+			Entry("terminating", &apiextensionsv1.CustomResourceDefinition{
+				Status: apiextensionsv1.CustomResourceDefinitionStatus{
+					Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
 						{
-							Type:   apiextensionsv1beta1.NamesAccepted,
-							Status: apiextensionsv1beta1.ConditionTrue,
+							Type:   apiextensionsv1.NamesAccepted,
+							Status: apiextensionsv1.ConditionTrue,
 						},
 						{
-							Type:   apiextensionsv1beta1.Established,
-							Status: apiextensionsv1beta1.ConditionTrue,
+							Type:   apiextensionsv1.Established,
+							Status: apiextensionsv1.ConditionTrue,
 						},
 						{
-							Type:   apiextensionsv1beta1.Terminating,
-							Status: apiextensionsv1beta1.ConditionTrue,
-						},
-					},
-				},
-			}, HaveOccurred()),
-			Entry("with conflicting name", &apiextensionsv1beta1.CustomResourceDefinition{
-				Status: apiextensionsv1beta1.CustomResourceDefinitionStatus{
-					Conditions: []apiextensionsv1beta1.CustomResourceDefinitionCondition{
-						{
-							Type:   apiextensionsv1beta1.NamesAccepted,
-							Status: apiextensionsv1beta1.ConditionFalse,
-						},
-						{
-							Type:   apiextensionsv1beta1.Established,
-							Status: apiextensionsv1beta1.ConditionFalse,
+							Type:   apiextensionsv1.Terminating,
+							Status: apiextensionsv1.ConditionTrue,
 						},
 					},
 				},
 			}, HaveOccurred()),
-			Entry("healthy", &apiextensionsv1beta1.CustomResourceDefinition{
-				Status: apiextensionsv1beta1.CustomResourceDefinitionStatus{
-					Conditions: []apiextensionsv1beta1.CustomResourceDefinitionCondition{
+			Entry("with conflicting name", &apiextensionsv1.CustomResourceDefinition{
+				Status: apiextensionsv1.CustomResourceDefinitionStatus{
+					Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
 						{
-							Type:   apiextensionsv1beta1.NamesAccepted,
-							Status: apiextensionsv1beta1.ConditionTrue,
+							Type:   apiextensionsv1.NamesAccepted,
+							Status: apiextensionsv1.ConditionFalse,
 						},
 						{
-							Type:   apiextensionsv1beta1.Established,
-							Status: apiextensionsv1beta1.ConditionTrue,
+							Type:   apiextensionsv1.Established,
+							Status: apiextensionsv1.ConditionFalse,
+						},
+					},
+				},
+			}, HaveOccurred()),
+			Entry("healthy", &apiextensionsv1.CustomResourceDefinition{
+				Status: apiextensionsv1.CustomResourceDefinitionStatus{
+					Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+						{
+							Type:   apiextensionsv1.NamesAccepted,
+							Status: apiextensionsv1.ConditionTrue,
+						},
+						{
+							Type:   apiextensionsv1.Established,
+							Status: apiextensionsv1.ConditionTrue,
 						},
 					},
 				},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority normal

**What this PR does / why we need it**:
This PR fixes CRD health checks which only worked for CRDs of version `v1beta1` and ran into conversion issues if `v1` was present.

Co-authored-by: DockToFuture <sebastian.stauch@sap.com>

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue has been fixed which caused failing health checks for `CustomResourceDefinitions` of version `v1`.
```
