### PR TITLE
add origin annotation to resources created an behalf of a managed resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /local
 /bin
 /dev
+/cmd/gardener-resource-manager/controller
 **/dev
 
 *.coverprofile

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -83,7 +83,7 @@ func NewResourceManagerCommand() *cobra.Command {
 			targetClientOpts.Completed().Apply(&healthControllerOpts.Completed().TargetClientConfig)
 			resourceControllerOpts.Completed().ApplyClassFilter(&secretControllerOpts.Completed().ClassFilter)
 			resourceControllerOpts.Completed().ApplyClassFilter(&healthControllerOpts.Completed().ClassFilter)
-			err := resourceControllerOpts.Completed().ApplyDefaultClusterId(entryLog, sourceClientOpts.Completed().RESTConfig)
+			err := resourceControllerOpts.Completed().ApplyDefaultClusterId(ctx, entryLog, sourceClientOpts.Completed().RESTConfig)
 			if err != nil {
 				return err
 			}

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -83,6 +83,10 @@ func NewResourceManagerCommand() *cobra.Command {
 			targetClientOpts.Completed().Apply(&healthControllerOpts.Completed().TargetClientConfig)
 			resourceControllerOpts.Completed().ApplyClassFilter(&secretControllerOpts.Completed().ClassFilter)
 			resourceControllerOpts.Completed().ApplyClassFilter(&healthControllerOpts.Completed().ClassFilter)
+			err := resourceControllerOpts.Completed().ApplyDefaultClusterId(entryLog, sourceClientOpts.Completed().RESTConfig)
+			if err != nil {
+				return err
+			}
 
 			// setup manager
 			mgr, err := manager.New(sourceClientOpts.Completed().RESTConfig, managerOptions)

--- a/docs/concepts/managed-resource.md
+++ b/docs/concepts/managed-resource.md
@@ -54,3 +54,28 @@ The following section describes a healthy ManagedResource:
 In some cases it is not desirable to update or re-apply some of the cluster components (for example, if customization is required or needs to be applied by the end-user). 
 For these resources, the annotation "resources.gardener.cloud/ignore" needs to be set to "true" or a truthy value (Truthy values are "1", "t", "T", "true", "TRUE", "True") in the corresponding managed resource secrets, 
 this can be done from the components that create the managed resource secrets, for example Gardener extensions or Gardener. Once this is done, the resource will be initially created and later ignored during reconciliation.
+
+## Origin
+
+All the objects managed by the resource manager get a dedicated annotation 
+`resources.gardener.cloud/origin` describing the `ManagedResource` object that describes 
+ this object. 
+ 
+ By default this is in this format &lt;namespace&gt;/&lt;objectname&gt;.
+ In multi-cluster scenarios (the `ManagedResource` objects are maintained in a 
+ cluster different from the one the described objects are managed), it might
+ be useful to include the cluster identity, as well.
+ 
+ This can be enforced by setting the `--cluster-id` option. Here, several
+ possibilities are supported:
+ - given a direct value: use this as id for the source cluster
+ - `<cluster>`: read the cluster identity from a `cluster-identity` config map
+  in the `kube-system` namespace (attribute `cluster-identity`). This is 
+  automatically maintained in all clusters managed or involved in a gardener landscape.
+ - `<default>`: try to read the cluster identity from the config map. If not found,
+  no identity is used
+ - empty string: no cluster identity is used (completely cluster local scenarios)
+ 
+ The format of the origin annotation with a cluster id is &lt;cluster id&gt;:&lt;namespace&gt;/&lt;objectname&gt;.
+ 
+ The default for the cluster id is the empty value (do not use cluster id).

--- a/pkg/controller/managedresource/merger.go
+++ b/pkg/controller/managedresource/merger.go
@@ -29,12 +29,14 @@ const (
 	descriptionAnnotation     = "resources.gardener.cloud/description"
 	descriptionAnnotationText = `DO NOT EDIT - This resource is managed by gardener-resource-manager.
 Any modifications are discarded and the resource is returned to the original state.`
+
+	originAnnotation = "resources.gardener.cloud/origin"
 )
 
 // merge merges the values of the `desired` object into the `current` object while preserving `current`'s important
 // metadata (like resourceVersion and finalizers), status and selected spec fields of the respective kind (e.g.
 // .spec.selector of a Job).
-func merge(desired, current *unstructured.Unstructured, forceOverwriteLabels bool, existingLabels map[string]string, forceOverwriteAnnotations bool, existingAnnotations map[string]string, preserveReplicas, preserveResources bool) error {
+func merge(origin string, desired, current *unstructured.Unstructured, forceOverwriteLabels bool, existingLabels map[string]string, forceOverwriteAnnotations bool, existingAnnotations map[string]string, preserveReplicas, preserveResources bool) error {
 	// save copy of current object before merging
 	oldObject := current.DeepCopy()
 
@@ -71,6 +73,7 @@ func merge(desired, current *unstructured.Unstructured, forceOverwriteLabels boo
 	}
 
 	ann[descriptionAnnotation] = descriptionAnnotationText
+	ann[originAnnotation] = origin
 	newObject.SetAnnotations(ann)
 
 	// keep status of old object if it is set and not empty

--- a/pkg/controller/managedresource/merger_test.go
+++ b/pkg/controller/managedresource/merger_test.go
@@ -34,6 +34,8 @@ import (
 
 var _ = Describe("merger", func() {
 
+	origin := "test:a/b"
+
 	Describe("#merge", func() {
 		var (
 			current, desired *unstructured.Unstructured
@@ -77,9 +79,9 @@ var _ = Describe("merger", func() {
 			desired.Object["metadata"] = nil
 
 			expected := current.DeepCopy()
-			addDescriptionAnnotations(expected)
+			addAnnotations(origin, expected)
 
-			Expect(merge(desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["metadata"]).To(Equal(expected.Object["metadata"]))
 		})
 
@@ -90,7 +92,7 @@ var _ = Describe("merger", func() {
 
 			expected := desired.DeepCopy()
 
-			Expect(merge(desired, current, true, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, true, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -105,7 +107,7 @@ var _ = Describe("merger", func() {
 				"other": "baz",
 			})
 
-			Expect(merge(desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -119,7 +121,7 @@ var _ = Describe("merger", func() {
 				"other": "baz",
 			})
 
-			Expect(merge(desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -134,7 +136,7 @@ var _ = Describe("merger", func() {
 				"other": "baz",
 			})
 
-			Expect(merge(desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, existingLabels, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetLabels()).To(Equal(expected.GetLabels()))
 		})
 
@@ -144,9 +146,9 @@ var _ = Describe("merger", func() {
 			existingAnnotations := map[string]string{"existing": "ignored"}
 
 			expected := desired.DeepCopy()
-			addDescriptionAnnotations(expected)
+			addAnnotations(origin, expected)
 
-			Expect(merge(desired, current, false, nil, true, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, true, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -160,9 +162,9 @@ var _ = Describe("merger", func() {
 				"foo":   "bar",
 				"other": "baz",
 			})
-			addDescriptionAnnotations(expected)
+			addAnnotations(origin, expected)
 
-			Expect(merge(desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -175,9 +177,9 @@ var _ = Describe("merger", func() {
 			expected.SetAnnotations(map[string]string{
 				"other": "baz",
 			})
-			addDescriptionAnnotations(expected)
+			addAnnotations(origin, expected)
 
-			Expect(merge(desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -191,9 +193,9 @@ var _ = Describe("merger", func() {
 				"foo":   "changed",
 				"other": "baz",
 			})
-			addDescriptionAnnotations(expected)
+			addAnnotations(origin, expected)
 
-			Expect(merge(desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, existingAnnotations, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.GetAnnotations()).To(Equal(expected.GetAnnotations()))
 		})
 
@@ -207,7 +209,7 @@ var _ = Describe("merger", func() {
 
 			expected := current.DeepCopy()
 
-			Expect(merge(desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(Equal(expected.Object["status"]))
 		})
 
@@ -218,7 +220,7 @@ var _ = Describe("merger", func() {
 
 			current.Object["status"] = map[string]interface{}{}
 
-			Expect(merge(desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(BeNil())
 		})
 
@@ -229,7 +231,7 @@ var _ = Describe("merger", func() {
 
 			delete(current.Object, "status")
 
-			Expect(merge(desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(current.Object["status"]).To(BeNil())
 		})
 
@@ -240,12 +242,12 @@ var _ = Describe("merger", func() {
 			})
 
 			It("when forceOverrideAnnotation is false", func() {
-				Expect(merge(desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+				Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
 			})
 			It("when forceOverrideAnnotation is false and old annotations exist", func() {
 				desired.SetAnnotations(map[string]string{"goo": "boo"})
 				current.SetAnnotations(map[string]string{"foo": "bar"})
-				Expect(merge(desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+				Expect(merge(origin, desired, current, false, nil, false, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
 
 				Expect(current.GetAnnotations()).To(HaveKeyWithValue("goo", "boo"))
 				Expect(current.GetAnnotations()).To(HaveKeyWithValue("foo", "bar"))
@@ -253,7 +255,7 @@ var _ = Describe("merger", func() {
 
 			It("when forceOverrideAnnotation is true", func() {
 				desired.SetAnnotations(map[string]string{"goo": "boo"})
-				Expect(merge(desired, current, false, nil, true, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
+				Expect(merge(origin, desired, current, false, nil, true, nil, false, false)).ToNot(HaveOccurred(), "merge succeeds")
 				Expect(current.GetAnnotations()).To(HaveKeyWithValue("goo", "boo"))
 			})
 		})
@@ -848,13 +850,13 @@ var _ = Describe("merger", func() {
 	})
 })
 
-func addDescriptionAnnotations(obj *unstructured.Unstructured) {
+func addAnnotations(origin string, obj *unstructured.Unstructured) {
 	ann := obj.GetAnnotations()
 
 	if ann == nil {
 		ann = make(map[string]string, 1)
 	}
 	ann[descriptionAnnotation] = descriptionAnnotationText
-
+	ann[originAnnotation] = origin
 	obj.SetAnnotations(ann)
 }

--- a/pkg/controller/managedresource/reconciler.go
+++ b/pkg/controller/managedresource/reconciler.go
@@ -26,13 +26,13 @@ import (
 
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/api/resources/v1alpha1"
 	resourcesv1alpha1helper "github.com/gardener/gardener-resource-manager/api/resources/v1alpha1/helper"
+	"github.com/hashicorp/go-multierror"
 
 	"github.com/gardener/gardener-resource-manager/pkg/controller/utils"
 	"github.com/gardener/gardener-resource-manager/pkg/filter"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/go-logr/logr"
-	"github.com/hashicorp/go-multierror"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1 "k8s.io/api/batch/v1"

--- a/pkg/controller/managedresource/reconciler.go
+++ b/pkg/controller/managedresource/reconciler.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/api/resources/v1alpha1"
 	resourcesv1alpha1helper "github.com/gardener/gardener-resource-manager/api/resources/v1alpha1/helper"
+
 	"github.com/gardener/gardener-resource-manager/pkg/controller/utils"
 	"github.com/gardener/gardener-resource-manager/pkg/filter"
 
@@ -470,19 +470,6 @@ func (r *Reconciler) origin(mr *resourcesv1alpha1.ManagedResource) string {
 		return r.clusterID + ":" + mr.Namespace + "/" + mr.Name
 	}
 	return mr.Namespace + "/" + mr.Name
-}
-
-func MatchOrigin(origin, found string) bool {
-	if found == origin {
-		return true
-	}
-	parts := strings.Split(origin, ":")
-	if len(parts) > 1 {
-		// handle format migration for adding cluster-id later
-		fparts := strings.Split(found, ":")
-		return len(fparts) == 1 && parts[1] == found
-	}
-	return false
 }
 
 // computeAllScaledObjectKeys returns two sets containing object keys (in the form `Group/Kind/Namespace/Name`).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:

The PR introduces an `origin` annotation for resources managed on-behalf of a _ManagedResource_.
An origin is typically a tripple cluster/namespace/name of the _ManagedResource_ object.
It can be used  by humans to figure out the _ManagedResource_ object used to manage an object just by looking at an object indicated to be maintained by a _ManagedResource_.

The cluster id  can be taken from the `cluster-identity` of the cluster, of specified manually by a `cluster-id` command line argument. Here three kinds of values are possible:
- `<cluster>`:  The cluster MUST have a cluster identity that is used.
- `<default>`:  If the cluster has a cluster identity it is used, otherwise a local scenario is assumed where the cluster is omitted from the origin
- some string: this identity is used. For resource managers on the seed handling shoot resources, a fixed value must be chosen (for example `seed`) to support control plane migrations.
- no value: the local scenario is selected where the cluster is omitted from the origin information.

This origin information can in a further step be used to support more deploy modes for objects that require the information whether an objects is deployed by the actual ManagedResource.

**Which issue(s) this PR fixes**:
Fixes #100

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
With this release for all objects managed by a `ManagedResource`  an annotation `resources.gardener.cloud/origin` is set describing the `ManagedResource` that caused
this object to be created. The format of the origin annotation is [<cluster id>:]<namespace>/<objectname>. For multi-cluster scenarios the GRM can be started with a
`--cluster-id` options to enable the extended annotation format
(see https://github.com/gardener/gardener-resource-manager/blob/master/docs/concepts/managed-resource.md
for further details).
 
```
