### PR TITLE
Conditions `lastUpdateTime` is no longer updated continuously

### DIFF
--- a/api/resources/v1alpha1/helper/helper.go
+++ b/api/resources/v1alpha1/helper/helper.go
@@ -25,12 +25,14 @@ var Now = metav1.Now
 
 // InitCondition initializes a new Condition with an Unknown status.
 func InitCondition(conditionType resourcesv1alpha1.ConditionType) resourcesv1alpha1.ManagedResourceCondition {
+	now := Now()
 	return resourcesv1alpha1.ManagedResourceCondition{
 		Type:               conditionType,
 		Status:             resourcesv1alpha1.ConditionUnknown,
 		Reason:             "ConditionInitialized",
 		Message:            "The condition has been initialized but its semantic check has not been performed yet.",
-		LastTransitionTime: Now(),
+		LastTransitionTime: now,
+		LastUpdateTime:     now,
 	}
 }
 
@@ -39,10 +41,10 @@ func InitCondition(conditionType resourcesv1alpha1.ConditionType) resourcesv1alp
 func GetCondition(conditions []resourcesv1alpha1.ManagedResourceCondition, conditionType resourcesv1alpha1.ConditionType) *resourcesv1alpha1.ManagedResourceCondition {
 	for _, condition := range conditions {
 		if condition.Type == conditionType {
-			return &condition
+			c := condition
+			return &c
 		}
 	}
-
 	return nil
 }
 
@@ -52,23 +54,29 @@ func GetOrInitCondition(conditions []resourcesv1alpha1.ManagedResourceCondition,
 	if condition := GetCondition(conditions, conditionType); condition != nil {
 		return *condition
 	}
-
 	return InitCondition(conditionType)
 }
 
 // UpdatedCondition updates the properties of one specific condition.
 func UpdatedCondition(condition resourcesv1alpha1.ManagedResourceCondition, status resourcesv1alpha1.ConditionStatus, reason, message string) resourcesv1alpha1.ManagedResourceCondition {
-	newCondition := resourcesv1alpha1.ManagedResourceCondition{
-		Type:               condition.Type,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: condition.LastTransitionTime,
-		LastUpdateTime:     Now(),
-	}
+	var (
+		newCondition = resourcesv1alpha1.ManagedResourceCondition{
+			Type:               condition.Type,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			LastTransitionTime: condition.LastTransitionTime,
+			LastUpdateTime:     condition.LastUpdateTime,
+		}
+		now = Now()
+	)
 
 	if condition.Status != status {
-		newCondition.LastTransitionTime = Now()
+		newCondition.LastTransitionTime = now
+	}
+
+	if condition.Reason != reason || condition.Message != message {
+		newCondition.LastUpdateTime = now
 	}
 
 	return newCondition

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -279,7 +279,7 @@ func NewControllerManagerCommand(parentCtx context.Context) *cobra.Command {
 
 			healthController, err := controller.New("health-controller", mgr, controller.Options{
 				MaxConcurrentReconciles: healthMaxConcurrentWorkers,
-				Reconciler: health.NewHealthReconciler(
+				Reconciler: health.NewReconciler(
 					ctx,
 					log.WithName("health-reconciler"),
 					mgr.GetClient(),

--- a/example/20-managedresource.yaml
+++ b/example/20-managedresource.yaml
@@ -45,7 +45,7 @@ stringData:
         spec:
           containers:
           - name: nginx
-            image: nginx:1.7.9
+            image: nginx:1.14.2
             ports:
             - containerPort: 80
 ---

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gardener/gardener-resource-manager
 go 1.15
 
 require (
-	github.com/gardener/gardener v1.11.3
+	github.com/gardener/gardener v1.12.8
 	github.com/gardener/gardener-resource-manager/api v0.0.0-00010101000000-000000000000
 	github.com/gardener/hvpa-controller v0.3.1
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/gardener/gardener v1.1.2/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGU
 github.com/gardener/gardener v1.3.1/go.mod h1:936P5tQbg6ViiW8BVC9ELM95sFrk4DgobKrxMNtn/LU=
 github.com/gardener/gardener v1.4.1-0.20200519155656-a8ccc6cc779a h1:Gq7N2Dbn4s9Wdn4Q+HrTozx6b8kfWh7J7rO1z2Lt5/g=
 github.com/gardener/gardener v1.4.1-0.20200519155656-a8ccc6cc779a/go.mod h1:t9oESM37bAMIuezi9I0H0I8+++8jy8BUPitcf4ERRXY=
-github.com/gardener/gardener v1.11.3 h1:9xI7Mq0XXKiv4W1c4/pvSqsIIRtlE2dLSTrZszWs8oc=
-github.com/gardener/gardener v1.11.3/go.mod h1:5DzqfOm+G8UftKu5zUbYJ+9Cnfd4XrvRNDabkM9AIp4=
+github.com/gardener/gardener v1.12.8 h1:LOmCBMxeyWzisRAjnYhDCLxugIhlhtDSbxZoxTphzQo=
+github.com/gardener/gardener v1.12.8/go.mod h1:N7MiaoNAPCKPq56p3z7P8yWyq5CTC28iZuiX+tGAjXk=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/gardener-resource-manager v0.13.1/go.mod h1:0No/XttYRUwDn5lSppq9EqlKdo/XJQ44aCZz5BVu3Vw=
 github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25/go.mod h1:yj7YJ6ijo4adcpXQKutPFZfQuKLdM5UMZZUlpbM3vig=

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/gardener/gardener-resource-manager/api/resources/v1alpha1"
 	"github.com/gardener/gardener-resource-manager/api/resources/v1alpha1/helper"
+
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/vendor/github.com/gardener/gardener-resource-manager/api/resources/v1alpha1/helper/helper.go
+++ b/vendor/github.com/gardener/gardener-resource-manager/api/resources/v1alpha1/helper/helper.go
@@ -25,12 +25,14 @@ var Now = metav1.Now
 
 // InitCondition initializes a new Condition with an Unknown status.
 func InitCondition(conditionType resourcesv1alpha1.ConditionType) resourcesv1alpha1.ManagedResourceCondition {
+	now := Now()
 	return resourcesv1alpha1.ManagedResourceCondition{
 		Type:               conditionType,
 		Status:             resourcesv1alpha1.ConditionUnknown,
 		Reason:             "ConditionInitialized",
 		Message:            "The condition has been initialized but its semantic check has not been performed yet.",
-		LastTransitionTime: Now(),
+		LastTransitionTime: now,
+		LastUpdateTime:     now,
 	}
 }
 
@@ -39,10 +41,10 @@ func InitCondition(conditionType resourcesv1alpha1.ConditionType) resourcesv1alp
 func GetCondition(conditions []resourcesv1alpha1.ManagedResourceCondition, conditionType resourcesv1alpha1.ConditionType) *resourcesv1alpha1.ManagedResourceCondition {
 	for _, condition := range conditions {
 		if condition.Type == conditionType {
-			return &condition
+			c := condition
+			return &c
 		}
 	}
-
 	return nil
 }
 
@@ -52,23 +54,29 @@ func GetOrInitCondition(conditions []resourcesv1alpha1.ManagedResourceCondition,
 	if condition := GetCondition(conditions, conditionType); condition != nil {
 		return *condition
 	}
-
 	return InitCondition(conditionType)
 }
 
 // UpdatedCondition updates the properties of one specific condition.
 func UpdatedCondition(condition resourcesv1alpha1.ManagedResourceCondition, status resourcesv1alpha1.ConditionStatus, reason, message string) resourcesv1alpha1.ManagedResourceCondition {
-	newCondition := resourcesv1alpha1.ManagedResourceCondition{
-		Type:               condition.Type,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: condition.LastTransitionTime,
-		LastUpdateTime:     Now(),
-	}
+	var (
+		newCondition = resourcesv1alpha1.ManagedResourceCondition{
+			Type:               condition.Type,
+			Status:             status,
+			Reason:             reason,
+			Message:            message,
+			LastTransitionTime: condition.LastTransitionTime,
+			LastUpdateTime:     condition.LastUpdateTime,
+		}
+		now = Now()
+	)
 
 	if condition.Status != status {
-		newCondition.LastTransitionTime = Now()
+		newCondition.LastTransitionTime = now
+	}
+
+	if condition.Reason != reason || condition.Message != message {
+		newCondition.LastUpdateTime = now
 	}
 
 	return newCondition

--- a/vendor/github.com/gardener/gardener/hack/test-cover.sh
+++ b/vendor/github.com/gardener/gardener/hack/test-cover.sh
@@ -21,9 +21,10 @@ echo "> Test Cover"
 
 GO111MODULE=on ginkgo -cover -race -mod=vendor $@
 
-COVERPROFILE="$(dirname $0)/../test.coverprofile"
-COVERPROFILE_TMP="$(dirname $0)/../test.coverprofile.tmp"
-COVERPROFILE_HTML="$(dirname $0)/../test.coverage.html"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+COVERPROFILE="$REPO_ROOT/test.coverprofile"
+COVERPROFILE_TMP="$REPO_ROOT/test.coverprofile.tmp"
+COVERPROFILE_HTML="$REPO_ROOT/test.coverage.html"
 
 echo "mode: set" > "$COVERPROFILE_TMP"
 find . -name "*.coverprofile" -type f | xargs cat | grep -v mode: | sort -r | awk '{if($1 != last) {print $0;last=$1}}' >> "$COVERPROFILE_TMP"

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/types_seed.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/types_seed.go
@@ -207,20 +207,6 @@ type SeedTaint struct {
 }
 
 const (
-	// DeprecatedSeedTaintDisableCapacityReservation is a constant for a taint key on a seed that marks it for disabling
-	// excess capacity reservation. This can be useful for seed clusters which only host shooted seeds to reduce
-	// costs.
-	// deprecated
-	DeprecatedSeedTaintDisableCapacityReservation = "seed.gardener.cloud/disable-capacity-reservation"
-	// DeprecatedSeedTaintDisableDNS is a constant for a taint key on a seed that marks it for disabling DNS. All shoots
-	// using this seed won't get any DNS providers, DNS records, and no DNS extension controller is required to
-	// be installed here. This is useful for environment where DNS is not required.
-	// deprecated
-	DeprecatedSeedTaintDisableDNS = "seed.gardener.cloud/disable-dns"
-	// DeprecatedSeedTaintInvisible is a constant for a taint key on a seed that marks it as invisible. Invisible seeds
-	// are not considered by the gardener-scheduler.
-	// deprecated
-	DeprecatedSeedTaintInvisible = "seed.gardener.cloud/invisible"
 	// SeedTaintProtected is a constant for a taint key on a seed that marks it as protected. Protected seeds
 	// may only be used by shoots in the `garden` namespace.
 	SeedTaintProtected = "seed.gardener.cloud/protected"

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/types_shoot.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/types_shoot.go
@@ -590,7 +590,7 @@ type KubeletConfig struct {
 	FailSwapOn *bool
 	// KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
-	// Default: cpu=80m,memory=1Gi
+	// Default: cpu=80m,memory=1Gi,pid=20k
 	KubeReserved *KubeletConfigReserved
 	// SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/defaults.go
@@ -103,37 +103,33 @@ func SetDefaults_Seed(obj *Seed) {
 	}
 
 	if obj.Spec.Settings.ExcessCapacityReservation == nil {
-		enabled := true
-		for _, taint := range obj.Spec.Taints {
-			if taint.Key == DeprecatedSeedTaintDisableCapacityReservation {
-				enabled = false
-			}
-		}
-		obj.Spec.Settings.ExcessCapacityReservation = &SeedSettingExcessCapacityReservation{Enabled: enabled}
+		obj.Spec.Settings.ExcessCapacityReservation = &SeedSettingExcessCapacityReservation{Enabled: true}
 	}
 
 	if obj.Spec.Settings.Scheduling == nil {
-		visible := true
-		for _, taint := range obj.Spec.Taints {
-			if taint.Key == DeprecatedSeedTaintInvisible {
-				visible = false
-			}
-		}
-		obj.Spec.Settings.Scheduling = &SeedSettingScheduling{Visible: visible}
+		obj.Spec.Settings.Scheduling = &SeedSettingScheduling{Visible: true}
 	}
 
 	if obj.Spec.Settings.ShootDNS == nil {
-		enabled := true
-		for _, taint := range obj.Spec.Taints {
-			if taint.Key == DeprecatedSeedTaintDisableDNS {
-				enabled = false
-			}
-		}
-		obj.Spec.Settings.ShootDNS = &SeedSettingShootDNS{Enabled: enabled}
+		obj.Spec.Settings.ShootDNS = &SeedSettingShootDNS{Enabled: true}
 	}
 
 	if obj.Spec.Settings.VerticalPodAutoscaler == nil {
 		obj.Spec.Settings.VerticalPodAutoscaler = &SeedSettingVerticalPodAutoscaler{Enabled: true}
+	}
+
+	// TODO: remove taints removal in version >=1.13
+	taintsToRemove := []string{
+		"seed.gardener.cloud/disable-capacity-reservation",
+		"seed.gardener.cloud/disable-dns",
+		"seed.gardener.cloud/invisible",
+	}
+	for _, taint := range taintsToRemove {
+		for i := len(obj.Spec.Taints) - 1; i >= 0; i-- {
+			if obj.Spec.Taints[i].Key == taint {
+				obj.Spec.Taints = append(obj.Spec.Taints[:i], obj.Spec.Taints[i+1:]...)
+			}
+		}
 	}
 }
 
@@ -211,16 +207,26 @@ func SetDefaults_Shoot(obj *Shoot) {
 	var (
 		kubeReservedMemory = resource.MustParse("1Gi")
 		kubeReservedCPU    = resource.MustParse("80m")
+		kubeReservedPID    = resource.MustParse("20k")
+
+		k8sVersionGreaterEqual115, _ = versionutils.CompareVersions(obj.Spec.Kubernetes.Version, ">=", "1.15")
 	)
 
 	if obj.Spec.Kubernetes.Kubelet.KubeReserved == nil {
 		obj.Spec.Kubernetes.Kubelet.KubeReserved = &KubeletConfigReserved{Memory: &kubeReservedMemory, CPU: &kubeReservedCPU}
+
+		if k8sVersionGreaterEqual115 {
+			obj.Spec.Kubernetes.Kubelet.KubeReserved.PID = &kubeReservedPID
+		}
 	} else {
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory = &kubeReservedMemory
 		}
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU = &kubeReservedCPU
+		}
+		if obj.Spec.Kubernetes.Kubelet.KubeReserved.PID == nil && k8sVersionGreaterEqual115 {
+			obj.Spec.Kubernetes.Kubelet.KubeReserved.PID = &kubeReservedPID
 		}
 	}
 

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/generated.proto
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/generated.proto
@@ -874,7 +874,7 @@ message KubeletConfig {
   // KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
   // When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
   // +optional
-  // Default: cpu=80m,memory=1Gi
+  // Default: cpu=80m,memory=1Gi,pid=20k
   optional KubeletConfigReserved kubeReserved = 14;
 
   // SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/types_seed.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/types_seed.go
@@ -231,20 +231,6 @@ type SeedTaint struct {
 }
 
 const (
-	// DeprecatedSeedTaintDisableCapacityReservation is a constant for a taint key on a seed that marks it for disabling
-	// excess capacity reservation. This can be useful for seed clusters which only host shooted seeds to reduce
-	// costs.
-	// deprecated
-	DeprecatedSeedTaintDisableCapacityReservation = "seed.gardener.cloud/disable-capacity-reservation"
-	// DeprecatedSeedTaintDisableDNS is a constant for a taint key on a seed that marks it for disabling DNS. All shoots
-	// using this seed won't get any DNS providers, DNS records, and no DNS extension controller is required to
-	// be installed here. This is useful for environment where DNS is not required.
-	// deprecated
-	DeprecatedSeedTaintDisableDNS = "seed.gardener.cloud/disable-dns"
-	// DeprecatedSeedTaintInvisible is a constant for a taint key on a seed that marks it as invisible. Invisible seeds
-	// are not considered by the gardener-scheduler.
-	// deprecated
-	DeprecatedSeedTaintInvisible = "seed.gardener.cloud/invisible"
 	// SeedTaintProtected is a constant for a taint key on a seed that marks it as protected. Protected seeds
 	// may only be used by shoots in the `garden` namespace.
 	SeedTaintProtected = "seed.gardener.cloud/protected"

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/types_shoot.go
@@ -737,7 +737,7 @@ type KubeletConfig struct {
 	// KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
 	// +optional
-	// Default: cpu=80m,memory=1Gi
+	// Default: cpu=80m,memory=1Gi,pid=20k
 	KubeReserved *KubeletConfigReserved `json:"kubeReserved,omitempty" protobuf:"bytes,14,opt,name=kubeReserved"`
 	// SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -36,6 +36,9 @@ const (
 	// SecretNameSSHKeyPair is a constant for the name of a Kubernetes secret object that contains the SSH key pair
 	// (public and private key) that can be used to SSH into the shoot nodes.
 	SecretNameSSHKeyPair = "ssh-keypair"
+	// SecretNameServiceAccountKey is a constant for the name of a Kubernetes secret object that contains a
+	// PEM-encoded private RSA or ECDSA key used by the Kube Controller Manager to sign service account tokens
+	SecretNameServiceAccountKey = "service-account-key"
 
 	// SecretNameGardener is a constant for the name of a Kubernetes secret object that contains the client
 	// certificate and a kubeconfig for a shoot cluster. It is used by Gardener and can be used by extension
@@ -249,6 +252,9 @@ const (
 	// AnnotationShootSkipCleanup is a key for an annotation on a Shoot resource that declares that the clean up steps should be skipped when the
 	// cluster is deleted. Concretely, this will skip everything except the deletion of (load balancer) services and persistent volume resources.
 	AnnotationShootSkipCleanup = "shoot.gardener.cloud/skip-cleanup"
+	// AnnotationShootKonnectivityTunnel is the key for an annotation of a Shoot cluster whose value indicates
+	// if a konnectivity-tunnel should be deployed into the shoot cluster or not.
+	AnnotationShootKonnectivityTunnel = "alpha.featuregates.shoot.gardener.cloud/konnectivity-tunnel"
 
 	// OperatingSystemConfigUnitNameKubeletService is a constant for a unit in the operating system config that contains the kubelet service.
 	OperatingSystemConfigUnitNameKubeletService = "kubelet.service"

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/defaults.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/defaults.go
@@ -103,37 +103,33 @@ func SetDefaults_Seed(obj *Seed) {
 	}
 
 	if obj.Spec.Settings.ExcessCapacityReservation == nil {
-		enabled := true
-		for _, taint := range obj.Spec.Taints {
-			if taint.Key == DeprecatedSeedTaintDisableCapacityReservation {
-				enabled = false
-			}
-		}
-		obj.Spec.Settings.ExcessCapacityReservation = &SeedSettingExcessCapacityReservation{Enabled: enabled}
+		obj.Spec.Settings.ExcessCapacityReservation = &SeedSettingExcessCapacityReservation{Enabled: true}
 	}
 
 	if obj.Spec.Settings.Scheduling == nil {
-		visible := true
-		for _, taint := range obj.Spec.Taints {
-			if taint.Key == DeprecatedSeedTaintInvisible {
-				visible = false
-			}
-		}
-		obj.Spec.Settings.Scheduling = &SeedSettingScheduling{Visible: visible}
+		obj.Spec.Settings.Scheduling = &SeedSettingScheduling{Visible: true}
 	}
 
 	if obj.Spec.Settings.ShootDNS == nil {
-		enabled := true
-		for _, taint := range obj.Spec.Taints {
-			if taint.Key == DeprecatedSeedTaintDisableDNS {
-				enabled = false
-			}
-		}
-		obj.Spec.Settings.ShootDNS = &SeedSettingShootDNS{Enabled: enabled}
+		obj.Spec.Settings.ShootDNS = &SeedSettingShootDNS{Enabled: true}
 	}
 
 	if obj.Spec.Settings.VerticalPodAutoscaler == nil {
 		obj.Spec.Settings.VerticalPodAutoscaler = &SeedSettingVerticalPodAutoscaler{Enabled: true}
+	}
+
+	// TODO: remove taints removal in version >=1.13
+	taintsToRemove := []string{
+		"seed.gardener.cloud/disable-capacity-reservation",
+		"seed.gardener.cloud/disable-dns",
+		"seed.gardener.cloud/invisible",
+	}
+	for _, taint := range taintsToRemove {
+		for i := len(obj.Spec.Taints) - 1; i >= 0; i-- {
+			if obj.Spec.Taints[i].Key == taint {
+				obj.Spec.Taints = append(obj.Spec.Taints[:i], obj.Spec.Taints[i+1:]...)
+			}
+		}
 	}
 }
 
@@ -211,16 +207,26 @@ func SetDefaults_Shoot(obj *Shoot) {
 	var (
 		kubeReservedMemory = resource.MustParse("1Gi")
 		kubeReservedCPU    = resource.MustParse("80m")
+		kubeReservedPID    = resource.MustParse("20k")
+
+		k8sVersionGreaterEqual115, _ = versionutils.CompareVersions(obj.Spec.Kubernetes.Version, ">=", "1.15")
 	)
 
 	if obj.Spec.Kubernetes.Kubelet.KubeReserved == nil {
 		obj.Spec.Kubernetes.Kubelet.KubeReserved = &KubeletConfigReserved{Memory: &kubeReservedMemory, CPU: &kubeReservedCPU}
+
+		if k8sVersionGreaterEqual115 {
+			obj.Spec.Kubernetes.Kubelet.KubeReserved.PID = &kubeReservedPID
+		}
 	} else {
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.Memory = &kubeReservedMemory
 		}
 		if obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU == nil {
 			obj.Spec.Kubernetes.Kubelet.KubeReserved.CPU = &kubeReservedCPU
+		}
+		if obj.Spec.Kubernetes.Kubelet.KubeReserved.PID == nil && k8sVersionGreaterEqual115 {
+			obj.Spec.Kubernetes.Kubelet.KubeReserved.PID = &kubeReservedPID
 		}
 	}
 

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/generated.proto
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/generated.proto
@@ -838,7 +838,7 @@ message KubeletConfig {
   // KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
   // When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
   // +optional
-  // Default: cpu=80m,memory=1Gi
+  // Default: cpu=80m,memory=1Gi,pid=20k
   optional KubeletConfigReserved kubeReserved = 14;
 
   // SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/types_seed.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/types_seed.go
@@ -230,22 +230,7 @@ type SeedTaint struct {
 	Value *string `json:"value,omitempty" protobuf:"bytes,2,opt,name=value"`
 }
 
-// TODO: Remove these taints in the next core.gardener.cloud API version in favor of the .spec.settings field.
 const (
-	// DeprecatedSeedTaintDisableCapacityReservation is a constant for a taint key on a seed that marks it for disabling
-	// excess capacity reservation. This can be useful for seed clusters which only host shooted seeds to reduce
-	// costs.
-	// deprecated
-	DeprecatedSeedTaintDisableCapacityReservation = "seed.gardener.cloud/disable-capacity-reservation"
-	// DeprecatedSeedTaintDisableDNS is a constant for a taint key on a seed that marks it for disabling DNS. All shoots
-	// using this seed won't get any DNS providers, DNS records, and no DNS extension controller is required to
-	// be installed here. This is useful for environment where DNS is not required.
-	// deprecated
-	DeprecatedSeedTaintDisableDNS = "seed.gardener.cloud/disable-dns"
-	// DeprecatedSeedTaintInvisible is a constant for a taint key on a seed that marks it as invisible. Invisible seeds
-	// are not considered by the gardener-scheduler.
-	// deprecated
-	DeprecatedSeedTaintInvisible = "seed.gardener.cloud/invisible"
 	// SeedTaintProtected is a constant for a taint key on a seed that marks it as protected. Protected seeds
 	// may only be used by shoots in the `garden` namespace.
 	SeedTaintProtected = "seed.gardener.cloud/protected"

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/types_shoot.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/types_shoot.go
@@ -734,7 +734,7 @@ type KubeletConfig struct {
 	// KubeReserved is the configuration for resources reserved for kubernetes node components (mainly kubelet and container runtime).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.
 	// +optional
-	// Default: cpu=80m,memory=1Gi
+	// Default: cpu=80m,memory=1Gi,pid=20k
 	KubeReserved *KubeletConfigReserved `json:"kubeReserved,omitempty" protobuf:"bytes,14,opt,name=kubeReserved"`
 	// SystemReserved is the configuration for resources reserved for system processes not managed by kubernetes (e.g. journald).
 	// When updating these values, be aware that cgroup resizes may not succeed on active worker nodes. Look for the NodeAllocatableEnforced event to determine if the configuration was applied.

--- a/vendor/github.com/gardener/gardener/pkg/client/kubernetes/client.go
+++ b/vendor/github.com/gardener/gardener/pkg/client/kubernetes/client.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	gardencoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	"github.com/gardener/gardener/pkg/client/kubernetes/utils"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	corev1 "k8s.io/api/core/v1"
@@ -261,9 +262,16 @@ func newClientSet(conf *Config) (Interface, error) {
 
 	var runtimeClient client.Client
 	if UseCachedRuntimeClients && !conf.disableCachedClient {
-		runtimeClient, err = newRuntimeClientWithCache(conf.restConfig, conf.clientOptions, runtimeCache)
-		if err != nil {
-			return nil, err
+		if cacheOpts := conf.cacheReaderOptions; cacheOpts != nil {
+			runtimeClient, err = utils.NewClientWithSpecificallyCachedReader(runtimeCache, conf.restConfig, conf.clientOptions, cacheOpts.readSpecifiedFromCache, cacheOpts.specificallyCachedObjects...)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			runtimeClient, err = newRuntimeClientWithCache(conf.restConfig, conf.clientOptions, runtimeCache)
+			if err != nil {
+				return nil, err
+			}
 		}
 	} else {
 		runtimeClient = directClient

--- a/vendor/github.com/gardener/gardener/pkg/client/kubernetes/options.go
+++ b/vendor/github.com/gardener/gardener/pkg/client/kubernetes/options.go
@@ -18,16 +18,25 @@ import (
 	"errors"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	baseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// Config carries options for new ClientSets.
 type Config struct {
 	clientOptions       client.Options
 	restConfig          *rest.Config
 	cacheResync         *time.Duration
 	disableCachedClient bool
+	cacheReaderOptions  *cacheReaderOptions
+}
+
+// cacheReaderOptions configures the specificallyCachedReader
+type cacheReaderOptions struct {
+	readSpecifiedFromCache    bool
+	specificallyCachedObjects []runtime.Object
 }
 
 // NewConfig returns a new Config with an empty REST config to allow testing ConfigFuncs without exporting
@@ -86,6 +95,28 @@ func WithCacheResyncPeriod(resync time.Duration) ConfigFunc {
 func WithDisabledCachedClient() ConfigFunc {
 	return func(config *Config) error {
 		config.disableCachedClient = true
+		return nil
+	}
+}
+
+// WithDisabledCacheFor disables the cached client for the specified objects' GroupKinds.
+func WithDisabledCacheFor(objects ...runtime.Object) ConfigFunc {
+	return func(config *Config) error {
+		config.cacheReaderOptions = &cacheReaderOptions{
+			readSpecifiedFromCache:    false,
+			specificallyCachedObjects: objects,
+		}
+		return nil
+	}
+}
+
+// WithEnabledCacheFor enables the cached client only for the specified objects' GroupKinds.
+func WithEnabledCacheFor(objects ...runtime.Object) ConfigFunc {
+	return func(config *Config) error {
+		config.cacheReaderOptions = &cacheReaderOptions{
+			readSpecifiedFromCache:    true,
+			specificallyCachedObjects: objects,
+		}
 		return nil
 	}
 }

--- a/vendor/github.com/gardener/gardener/pkg/client/kubernetes/scaling.go
+++ b/vendor/github.com/gardener/gardener/pkg/client/kubernetes/scaling.go
@@ -16,48 +16,58 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
 
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ScaleStatefulSet scales a StatefulSet.
 func ScaleStatefulSet(ctx context.Context, c client.Client, key client.ObjectKey, replicas int32) error {
-	// TODO: replace this with call to scale subresource once controller-runtime supports it
-	// see: https://github.com/kubernetes-sigs/controller-runtime/issues/172
-	statefulset := &appsv1.StatefulSet{}
-	if err := c.Get(ctx, key, statefulset); err != nil {
-		return err
+	statefulset := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
 	}
 
-	statefulset.Spec.Replicas = &replicas
-	return c.Update(ctx, statefulset)
+	return scaleResource(ctx, c, statefulset, replicas)
 }
 
 // ScaleEtcd scales a Etcd resource.
 func ScaleEtcd(ctx context.Context, c client.Client, key client.ObjectKey, replicas int) error {
-	// TODO: replace this with call to scale subresource once controller-runtime supports it
-	// see: https://github.com/kubernetes-sigs/controller-runtime/issues/172
-	etcd := &druidv1alpha1.Etcd{}
-	if err := c.Get(ctx, key, etcd); err != nil {
-		return err
+	etcd := &druidv1alpha1.Etcd{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
 	}
 
-	etcd.Spec.Replicas = replicas
-	return c.Update(ctx, etcd)
+	return scaleResource(ctx, c, etcd, int32(replicas))
 }
 
 // ScaleDeployment scales a Deployment.
 func ScaleDeployment(ctx context.Context, c client.Client, key client.ObjectKey, replicas int32) error {
-	// TODO: replace this with call to scale subresource once controller-runtime supports it
-	// see: https://github.com/kubernetes-sigs/controller-runtime/issues/172
-	deployment := &appsv1.Deployment{}
-	if err := c.Get(ctx, key, deployment); err != nil {
-		return err
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
 	}
 
-	deployment.Spec.Replicas = &replicas
-	return c.Update(ctx, deployment)
+	return scaleResource(ctx, c, deployment, replicas)
+}
+
+// scaleResource scales resource's 'spec.replicas' to replicas count
+func scaleResource(ctx context.Context, c client.Client, obj runtime.Object, replicas int32) error {
+	patch := []byte(fmt.Sprintf(`{"spec":{"replicas":%d}}`, replicas))
+
+	// TODO: replace this with call to scale subresource once controller-runtime supports it
+	// see: https://github.com/kubernetes-sigs/controller-runtime/issues/172
+	return c.Patch(ctx, obj, client.RawPatch(types.MergePatchType, patch))
 }

--- a/vendor/github.com/gardener/gardener/pkg/client/kubernetes/types.go
+++ b/vendor/github.com/gardener/gardener/pkg/client/kubernetes/types.go
@@ -67,6 +67,11 @@ var (
 		client.GracePeriodSeconds(0),
 	}
 
+	// SeedSerializer is a YAML serializer using the Seed scheme.
+	SeedSerializer = json.NewSerializerWithOptions(json.DefaultMetaFactory, SeedScheme, SeedScheme, json.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
+	// SeedCodec is a codec factory using the Seed scheme.
+	SeedCodec = serializer.NewCodecFactory(SeedScheme)
+
 	// ShootSerializer is a YAML serializer using the Shoot scheme.
 	ShootSerializer = json.NewSerializerWithOptions(json.DefaultMetaFactory, ShootScheme, ShootScheme, json.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
 	// ShootCodec is a codec factory using the Shoot scheme.

--- a/vendor/github.com/gardener/gardener/pkg/client/kubernetes/utils/client.go
+++ b/vendor/github.com/gardener/gardener/pkg/client/kubernetes/utils/client.go
@@ -1,0 +1,186 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// NewClientFuncWithSpecificallyCachedReader returns a manager.NewClientFunc that creates a new client.Client that either
+// - reads directly from the API server by default but reads the specified objects from the cache (readSpecifiedFromCache=true)
+// - or reads from the cache by default but reads the specified objects directly from the API server (readSpecifiedFromCache=true).
+func NewClientFuncWithSpecificallyCachedReader(readSpecifiedFromCache bool, specifiedObjects ...runtime.Object) manager.NewClientFunc {
+	return func(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
+		return NewClientWithSpecificallyCachedReader(cache, config, options, readSpecifiedFromCache, specifiedObjects...)
+	}
+}
+
+// NewClientFuncWithDisabledCacheFor returns a manager.NewClientFunc that creates a new client.Client that reads from
+// the cache by default but reads the specified objects directly from the API server.
+func NewClientFuncWithDisabledCacheFor(directlyReadingObjects ...runtime.Object) manager.NewClientFunc {
+	return NewClientFuncWithSpecificallyCachedReader(false, directlyReadingObjects...)
+}
+
+// NewClientFuncWithEnabledCacheFor returns a manager.NewClientFunc that creates a new client.Client that reads directly
+// from the API server by default but reads the specified objects from the cache.
+func NewClientFuncWithEnabledCacheFor(cachedObjects ...runtime.Object) manager.NewClientFunc {
+	return NewClientFuncWithSpecificallyCachedReader(true, cachedObjects...)
+}
+
+// NewClientWithSpecificallyCachedReader creates a new client.Client that either
+// - reads directly from the API server by default but reads the specified objects from the cache (readSpecifiedFromCache=true)
+// - or reads from the cache by default but reads the specified objects directly from the API server (readSpecifiedFromCache=false).
+func NewClientWithSpecificallyCachedReader(cache cache.Cache, config *rest.Config, options client.Options, readSpecifiedFromCache bool, specifiedObjects ...runtime.Object) (client.Client, error) {
+	// create the default Client
+	c, err := client.New(config, options)
+	if err != nil {
+		return nil, err
+	}
+
+	// create cache Reader that decides which objects to read from the cache and which to read directly from the API server
+	cacheReader, err := NewSpecificallyCachedReaderFor(
+		cache,
+		c,
+		options.Scheme,
+		readSpecifiedFromCache,
+		specifiedObjects...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client.DelegatingClient{
+		Reader: &client.DelegatingReader{
+			CacheReader:  cacheReader,
+			ClientReader: c,
+		},
+		Writer:       c,
+		StatusClient: c,
+	}, nil
+}
+
+// NewSpecificallyCachedReaderFor creates a new client.Reader that either
+// - reads directly from the API server by default but reads the specified objects from the cache (readSpecifiedFromCache=true)
+// - or reads from the cache by default but reads the specified objects directly from the API server (readSpecifiedFromCache=false).
+func NewSpecificallyCachedReaderFor(cacheReader, clientReader client.Reader, scheme *runtime.Scheme, readSpecifiedFromCache bool, objectKinds ...runtime.Object) (client.Reader, error) {
+	if scheme == nil {
+		scheme = kubernetesscheme.Scheme
+	}
+
+	delegatingRule, err := newDelegationRule(scheme, readSpecifiedFromCache, objectKinds...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &specificallyCachedReader{
+		shouldReadObjectFromCache: delegatingRule,
+		cacheReader:               cacheReader,
+		clientReader:              clientReader,
+	}, nil
+}
+
+// NewReaderWithDisabledCacheFor creates a new client.Reader that reads from the cache by default but reads the
+// specified objects directly from the API server.
+func NewReaderWithDisabledCacheFor(cacheReader, clientReader client.Reader, scheme *runtime.Scheme, directlyReadingObjects ...runtime.Object) (client.Reader, error) {
+	return NewSpecificallyCachedReaderFor(cacheReader, clientReader, scheme, false, directlyReadingObjects...)
+}
+
+// NewReaderWithEnabledCacheFor creates a new client.Reader that reads directly from the API server by default but reads
+// the specified objects from the cache.
+func NewReaderWithEnabledCacheFor(cacheReader, clientReader client.Reader, scheme *runtime.Scheme, cachedObjects ...runtime.Object) (client.Reader, error) {
+	return NewSpecificallyCachedReaderFor(cacheReader, clientReader, scheme, true, cachedObjects...)
+}
+
+// specificallyCachedReader implements client.Reader and delegates calls to the cache or direct client according to the
+// given delegationRule.
+type specificallyCachedReader struct {
+	shouldReadObjectFromCache delegationRule
+
+	cacheReader  client.Reader
+	clientReader client.Reader
+}
+
+// delegationRule is a function that decides whether a given object should be read from the cache or directly from the
+// API server.
+type delegationRule func(obj runtime.Object) (readFromCache bool, err error)
+
+// newDelegationRule returns a delegationRule, that will either
+// - only allow to read the specified object kinds from the cache (readSpecifiedFromCache=true)
+// - or only read the specified object kinds directly from the API server (readSpecifiedFromCache=false)
+func newDelegationRule(scheme *runtime.Scheme, readSpecifiedFromCache bool, objs ...runtime.Object) (delegationRule, error) {
+	specifiedGKs := make(map[schema.GroupKind]struct{})
+
+	for _, obj := range objs {
+		gvk, err := apiutil.GVKForObject(obj, scheme)
+		if err != nil {
+			return nil, err
+		}
+		specifiedGKs[gvk.GroupKind()] = struct{}{}
+	}
+
+	return func(obj runtime.Object) (readFromCache bool, err error) {
+		gvk, err := apiutil.GVKForObject(obj, scheme)
+		if err != nil {
+			return false, err
+		}
+
+		if strings.HasSuffix(gvk.Kind, "List") && meta.IsListType(obj) {
+			// if this is a list, treat it as a request for the item's resource
+			gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+		}
+
+		_, ok := specifiedGKs[gvk.GroupKind()]
+		// read from cache if GroupKind was specified and readSpecifiedFromCache=true
+		//   or GroupKind was not specified and readSpecifiedFromCache=false
+		return ok == readSpecifiedFromCache, nil
+	}, nil
+}
+
+// Get implements client.Reader by delegating calls either to the cache or the direct client based on the decision of
+// the delegationRule.
+func (s *specificallyCachedReader) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	useCache, err := s.shouldReadObjectFromCache(obj)
+	if err != nil {
+		return err
+	}
+	if useCache {
+		return s.cacheReader.Get(ctx, key, obj)
+	}
+	return s.clientReader.Get(ctx, key, obj)
+}
+
+// List implements client.Reader by delegating calls either to the cache or the direct client based on the decision of
+// the delegationRule.
+func (s *specificallyCachedReader) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	useCache, err := s.shouldReadObjectFromCache(list)
+	if err != nil {
+		return err
+	}
+	if useCache {
+		return s.cacheReader.List(ctx, list, opts...)
+	}
+	return s.clientReader.List(ctx, list, opts...)
+}

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/object.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/object.go
@@ -18,16 +18,9 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// Object is wrapper interface combining runtime.Object and metav1.Object interfaces together.
-type Object interface {
-	runtime.Object
-	metav1.Object
-}
 
 // ObjectName returns the name of the given object in the format <namespace>/<name>
 func ObjectName(obj runtime.Object) string {

--- a/vendor/github.com/gardener/gardener/pkg/utils/labels.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/labels.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// MustNewRequirement creates a labels.Requirement with the given values and panics if there is an error.
+func MustNewRequirement(key string, op selection.Operator, vals ...string) labels.Requirement {
+	req, err := labels.NewRequirement(key, op, vals)
+	utilruntime.Must(err)
+	return *req
+}

--- a/vendor/github.com/onsi/gomega/gstruct/elements.go
+++ b/vendor/github.com/onsi/gomega/gstruct/elements.go
@@ -1,0 +1,161 @@
+// untested sections: 6
+
+package gstruct
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime/debug"
+
+	"github.com/onsi/gomega/format"
+	errorsutil "github.com/onsi/gomega/gstruct/errors"
+	"github.com/onsi/gomega/types"
+)
+
+//MatchAllElements succeeds if every element of a slice matches the element matcher it maps to
+//through the id function, and every element matcher is matched.
+//    idFn := func(element interface{}) string {
+//        return fmt.Sprintf("%v", element)
+//    }
+//
+//    Expect([]string{"a", "b"}).To(MatchAllElements(idFn, Elements{
+//        "a": Equal("a"),
+//        "b": Equal("b"),
+//    }))
+func MatchAllElements(identifier Identifier, elements Elements) types.GomegaMatcher {
+	return &ElementsMatcher{
+		Identifier: identifier,
+		Elements:   elements,
+	}
+}
+
+//MatchElements succeeds if each element of a slice matches the element matcher it maps to
+//through the id function. It can ignore extra elements and/or missing elements.
+//    idFn := func(element interface{}) string {
+//        return fmt.Sprintf("%v", element)
+//    }
+//
+//    Expect([]string{"a", "b", "c"}).To(MatchElements(idFn, IgnoreExtras, Elements{
+//        "a": Equal("a"),
+//        "b": Equal("b"),
+//    }))
+//    Expect([]string{"a", "c"}).To(MatchElements(idFn, IgnoreMissing, Elements{
+//        "a": Equal("a"),
+//        "b": Equal("b"),
+//        "c": Equal("c"),
+//        "d": Equal("d"),
+//    }))
+func MatchElements(identifier Identifier, options Options, elements Elements) types.GomegaMatcher {
+	return &ElementsMatcher{
+		Identifier:      identifier,
+		Elements:        elements,
+		IgnoreExtras:    options&IgnoreExtras != 0,
+		IgnoreMissing:   options&IgnoreMissing != 0,
+		AllowDuplicates: options&AllowDuplicates != 0,
+	}
+}
+
+// ElementsMatcher is a NestingMatcher that applies custom matchers to each element of a slice mapped
+// by the Identifier function.
+// TODO: Extend this to work with arrays & maps (map the key) as well.
+type ElementsMatcher struct {
+	// Matchers for each element.
+	Elements Elements
+	// Function mapping an element to the string key identifying its matcher.
+	Identifier Identifier
+
+	// Whether to ignore extra elements or consider it an error.
+	IgnoreExtras bool
+	// Whether to ignore missing elements or consider it an error.
+	IgnoreMissing bool
+	// Whether to key duplicates when matching IDs.
+	AllowDuplicates bool
+
+	// State.
+	failures []error
+}
+
+// Element ID to matcher.
+type Elements map[string]types.GomegaMatcher
+
+// Function for identifying (mapping) elements.
+type Identifier func(element interface{}) string
+
+func (m *ElementsMatcher) Match(actual interface{}) (success bool, err error) {
+	if reflect.TypeOf(actual).Kind() != reflect.Slice {
+		return false, fmt.Errorf("%v is type %T, expected slice", actual, actual)
+	}
+
+	m.failures = m.matchElements(actual)
+	if len(m.failures) > 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *ElementsMatcher) matchElements(actual interface{}) (errs []error) {
+	// Provide more useful error messages in the case of a panic.
+	defer func() {
+		if err := recover(); err != nil {
+			errs = append(errs, fmt.Errorf("panic checking %+v: %v\n%s", actual, err, debug.Stack()))
+		}
+	}()
+
+	val := reflect.ValueOf(actual)
+	elements := map[string]bool{}
+	for i := 0; i < val.Len(); i++ {
+		element := val.Index(i).Interface()
+		id := m.Identifier(element)
+		if elements[id] {
+			if !m.AllowDuplicates {
+				errs = append(errs, fmt.Errorf("found duplicate element ID %s", id))
+				continue
+			}
+		}
+		elements[id] = true
+
+		matcher, expected := m.Elements[id]
+		if !expected {
+			if !m.IgnoreExtras {
+				errs = append(errs, fmt.Errorf("unexpected element %s", id))
+			}
+			continue
+		}
+
+		match, err := matcher.Match(element)
+		if match {
+			continue
+		}
+
+		if err == nil {
+			if nesting, ok := matcher.(errorsutil.NestingMatcher); ok {
+				err = errorsutil.AggregateError(nesting.Failures())
+			} else {
+				err = errors.New(matcher.FailureMessage(element))
+			}
+		}
+		errs = append(errs, errorsutil.Nest(fmt.Sprintf("[%s]", id), err))
+	}
+
+	for id := range m.Elements {
+		if !elements[id] && !m.IgnoreMissing {
+			errs = append(errs, fmt.Errorf("missing expected element %s", id))
+		}
+	}
+
+	return errs
+}
+
+func (m *ElementsMatcher) FailureMessage(actual interface{}) (message string) {
+	failure := errorsutil.AggregateError(m.failures)
+	return format.Message(actual, fmt.Sprintf("to match elements: %v", failure))
+}
+
+func (m *ElementsMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to match elements")
+}
+
+func (m *ElementsMatcher) Failures() []error {
+	return m.failures
+}

--- a/vendor/github.com/onsi/gomega/gstruct/errors/nested_types.go
+++ b/vendor/github.com/onsi/gomega/gstruct/errors/nested_types.go
@@ -1,0 +1,72 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega/types"
+)
+
+// A stateful matcher that nests other matchers within it and preserves the error types of the
+// nested matcher failures.
+type NestingMatcher interface {
+	types.GomegaMatcher
+
+	// Returns the failures of nested matchers.
+	Failures() []error
+}
+
+// An error type for labeling errors on deeply nested matchers.
+type NestedError struct {
+	Path string
+	Err  error
+}
+
+func (e *NestedError) Error() string {
+	// Indent Errors.
+	indented := strings.Replace(e.Err.Error(), "\n", "\n\t", -1)
+	return fmt.Sprintf("%s:\n\t%v", e.Path, indented)
+}
+
+// Create a NestedError with the given path.
+// If err is a NestedError, prepend the path to it.
+// If err is an AggregateError, recursively Nest each error.
+func Nest(path string, err error) error {
+	if ag, ok := err.(AggregateError); ok {
+		var errs AggregateError
+		for _, e := range ag {
+			errs = append(errs, Nest(path, e))
+		}
+		return errs
+	}
+	if ne, ok := err.(*NestedError); ok {
+		return &NestedError{
+			Path: path + ne.Path,
+			Err:  ne.Err,
+		}
+	}
+	return &NestedError{
+		Path: path,
+		Err:  err,
+	}
+}
+
+// An error type for treating multiple errors as a single error.
+type AggregateError []error
+
+// Error is part of the error interface.
+func (err AggregateError) Error() string {
+	if len(err) == 0 {
+		// This should never happen, really.
+		return ""
+	}
+	if len(err) == 1 {
+		return err[0].Error()
+	}
+	result := fmt.Sprintf("[%s", err[0].Error())
+	for i := 1; i < len(err); i++ {
+		result += fmt.Sprintf(", %s", err[i].Error())
+	}
+	result += "]"
+	return result
+}

--- a/vendor/github.com/onsi/gomega/gstruct/fields.go
+++ b/vendor/github.com/onsi/gomega/gstruct/fields.go
@@ -1,0 +1,165 @@
+// untested sections: 6
+
+package gstruct
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime/debug"
+	"strings"
+
+	"github.com/onsi/gomega/format"
+	errorsutil "github.com/onsi/gomega/gstruct/errors"
+	"github.com/onsi/gomega/types"
+)
+
+//MatchAllFields succeeds if every field of a struct matches the field matcher associated with
+//it, and every element matcher is matched.
+//    actual := struct{
+//      A int
+//      B []bool
+//      C string
+//    }{
+//      A: 5,
+//      B: []bool{true, false},
+//      C: "foo",
+//    }
+//
+//    Expect(actual).To(MatchAllFields(Fields{
+//      "A": Equal(5),
+//      "B": ConsistOf(true, false),
+//      "C": Equal("foo"),
+//    }))
+func MatchAllFields(fields Fields) types.GomegaMatcher {
+	return &FieldsMatcher{
+		Fields: fields,
+	}
+}
+
+//MatchFields succeeds if each element of a struct matches the field matcher associated with
+//it. It can ignore extra fields and/or missing fields.
+//    actual := struct{
+//      A int
+//      B []bool
+//      C string
+//    }{
+//      A: 5,
+//      B: []bool{true, false},
+//      C: "foo",
+//    }
+//
+//    Expect(actual).To(MatchFields(IgnoreExtras, Fields{
+//      "A": Equal(5),
+//      "B": ConsistOf(true, false),
+//    }))
+//    Expect(actual).To(MatchFields(IgnoreMissing, Fields{
+//      "A": Equal(5),
+//      "B": ConsistOf(true, false),
+//      "C": Equal("foo"),
+//      "D": Equal("extra"),
+//    }))
+func MatchFields(options Options, fields Fields) types.GomegaMatcher {
+	return &FieldsMatcher{
+		Fields:        fields,
+		IgnoreExtras:  options&IgnoreExtras != 0,
+		IgnoreMissing: options&IgnoreMissing != 0,
+	}
+}
+
+type FieldsMatcher struct {
+	// Matchers for each field.
+	Fields Fields
+
+	// Whether to ignore extra elements or consider it an error.
+	IgnoreExtras bool
+	// Whether to ignore missing elements or consider it an error.
+	IgnoreMissing bool
+
+	// State.
+	failures []error
+}
+
+// Field name to matcher.
+type Fields map[string]types.GomegaMatcher
+
+func (m *FieldsMatcher) Match(actual interface{}) (success bool, err error) {
+	if reflect.TypeOf(actual).Kind() != reflect.Struct {
+		return false, fmt.Errorf("%v is type %T, expected struct", actual, actual)
+	}
+
+	m.failures = m.matchFields(actual)
+	if len(m.failures) > 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *FieldsMatcher) matchFields(actual interface{}) (errs []error) {
+	val := reflect.ValueOf(actual)
+	typ := val.Type()
+	fields := map[string]bool{}
+	for i := 0; i < val.NumField(); i++ {
+		fieldName := typ.Field(i).Name
+		fields[fieldName] = true
+
+		err := func() (err error) {
+			// This test relies heavily on reflect, which tends to panic.
+			// Recover here to provide more useful error messages in that case.
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("panic checking %+v: %v\n%s", actual, r, debug.Stack())
+				}
+			}()
+
+			matcher, expected := m.Fields[fieldName]
+			if !expected {
+				if !m.IgnoreExtras {
+					return fmt.Errorf("unexpected field %s: %+v", fieldName, actual)
+				}
+				return nil
+			}
+
+			field := val.Field(i).Interface()
+
+			match, err := matcher.Match(field)
+			if err != nil {
+				return err
+			} else if !match {
+				if nesting, ok := matcher.(errorsutil.NestingMatcher); ok {
+					return errorsutil.AggregateError(nesting.Failures())
+				}
+				return errors.New(matcher.FailureMessage(field))
+			}
+			return nil
+		}()
+		if err != nil {
+			errs = append(errs, errorsutil.Nest("."+fieldName, err))
+		}
+	}
+
+	for field := range m.Fields {
+		if !fields[field] && !m.IgnoreMissing {
+			errs = append(errs, fmt.Errorf("missing expected field %s", field))
+		}
+	}
+
+	return errs
+}
+
+func (m *FieldsMatcher) FailureMessage(actual interface{}) (message string) {
+	failures := make([]string, len(m.failures))
+	for i := range m.failures {
+		failures[i] = m.failures[i].Error()
+	}
+	return format.Message(reflect.TypeOf(actual).Name(),
+		fmt.Sprintf("to match fields: {\n%v\n}\n", strings.Join(failures, "\n")))
+}
+
+func (m *FieldsMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to match fields")
+}
+
+func (m *FieldsMatcher) Failures() []error {
+	return m.failures
+}

--- a/vendor/github.com/onsi/gomega/gstruct/ignore.go
+++ b/vendor/github.com/onsi/gomega/gstruct/ignore.go
@@ -1,0 +1,39 @@
+// untested sections: 2
+
+package gstruct
+
+import (
+	"github.com/onsi/gomega/types"
+)
+
+//Ignore ignores the actual value and always succeeds.
+//  Expect(nil).To(Ignore())
+//  Expect(true).To(Ignore())
+func Ignore() types.GomegaMatcher {
+	return &IgnoreMatcher{true}
+}
+
+//Reject ignores the actual value and always fails. It can be used in conjunction with IgnoreMissing
+//to catch problematic elements, or to verify tests are running.
+//  Expect(nil).NotTo(Reject())
+//  Expect(true).NotTo(Reject())
+func Reject() types.GomegaMatcher {
+	return &IgnoreMatcher{false}
+}
+
+// A matcher that either always succeeds or always fails.
+type IgnoreMatcher struct {
+	Succeed bool
+}
+
+func (m *IgnoreMatcher) Match(actual interface{}) (bool, error) {
+	return m.Succeed, nil
+}
+
+func (m *IgnoreMatcher) FailureMessage(_ interface{}) (message string) {
+	return "Unconditional failure"
+}
+
+func (m *IgnoreMatcher) NegatedFailureMessage(_ interface{}) (message string) {
+	return "Unconditional success"
+}

--- a/vendor/github.com/onsi/gomega/gstruct/keys.go
+++ b/vendor/github.com/onsi/gomega/gstruct/keys.go
@@ -1,0 +1,126 @@
+// untested sections: 6
+
+package gstruct
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime/debug"
+	"strings"
+
+	"github.com/onsi/gomega/format"
+	errorsutil "github.com/onsi/gomega/gstruct/errors"
+	"github.com/onsi/gomega/types"
+)
+
+func MatchAllKeys(keys Keys) types.GomegaMatcher {
+	return &KeysMatcher{
+		Keys: keys,
+	}
+}
+
+func MatchKeys(options Options, keys Keys) types.GomegaMatcher {
+	return &KeysMatcher{
+		Keys:          keys,
+		IgnoreExtras:  options&IgnoreExtras != 0,
+		IgnoreMissing: options&IgnoreMissing != 0,
+	}
+}
+
+type KeysMatcher struct {
+	// Matchers for each key.
+	Keys Keys
+
+	// Whether to ignore extra keys or consider it an error.
+	IgnoreExtras bool
+	// Whether to ignore missing keys or consider it an error.
+	IgnoreMissing bool
+
+	// State.
+	failures []error
+}
+
+type Keys map[interface{}]types.GomegaMatcher
+
+func (m *KeysMatcher) Match(actual interface{}) (success bool, err error) {
+	if reflect.TypeOf(actual).Kind() != reflect.Map {
+		return false, fmt.Errorf("%v is type %T, expected map", actual, actual)
+	}
+
+	m.failures = m.matchKeys(actual)
+	if len(m.failures) > 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (m *KeysMatcher) matchKeys(actual interface{}) (errs []error) {
+	actualValue := reflect.ValueOf(actual)
+	keys := map[interface{}]bool{}
+	for _, keyValue := range actualValue.MapKeys() {
+		key := keyValue.Interface()
+		keys[key] = true
+
+		err := func() (err error) {
+			// This test relies heavily on reflect, which tends to panic.
+			// Recover here to provide more useful error messages in that case.
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("panic checking %+v: %v\n%s", actual, r, debug.Stack())
+				}
+			}()
+
+			matcher, ok := m.Keys[key]
+			if !ok {
+				if !m.IgnoreExtras {
+					return fmt.Errorf("unexpected key %s: %+v", key, actual)
+				}
+				return nil
+			}
+
+			valInterface := actualValue.MapIndex(keyValue).Interface()
+
+			match, err := matcher.Match(valInterface)
+			if err != nil {
+				return err
+			}
+
+			if !match {
+				if nesting, ok := matcher.(errorsutil.NestingMatcher); ok {
+					return errorsutil.AggregateError(nesting.Failures())
+				}
+				return errors.New(matcher.FailureMessage(valInterface))
+			}
+			return nil
+		}()
+		if err != nil {
+			errs = append(errs, errorsutil.Nest(fmt.Sprintf(".%#v", key), err))
+		}
+	}
+
+	for key := range m.Keys {
+		if !keys[key] && !m.IgnoreMissing {
+			errs = append(errs, fmt.Errorf("missing expected key %s", key))
+		}
+	}
+
+	return errs
+}
+
+func (m *KeysMatcher) FailureMessage(actual interface{}) (message string) {
+	failures := make([]string, len(m.failures))
+	for i := range m.failures {
+		failures[i] = m.failures[i].Error()
+	}
+	return format.Message(reflect.TypeOf(actual).Name(),
+		fmt.Sprintf("to match keys: {\n%v\n}\n", strings.Join(failures, "\n")))
+}
+
+func (m *KeysMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to match keys")
+}
+
+func (m *KeysMatcher) Failures() []error {
+	return m.failures
+}

--- a/vendor/github.com/onsi/gomega/gstruct/pointer.go
+++ b/vendor/github.com/onsi/gomega/gstruct/pointer.go
@@ -1,0 +1,58 @@
+// untested sections: 3
+
+package gstruct
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+)
+
+//PointTo applies the given matcher to the value pointed to by actual. It fails if the pointer is
+//nil.
+//  actual := 5
+//  Expect(&actual).To(PointTo(Equal(5)))
+func PointTo(matcher types.GomegaMatcher) types.GomegaMatcher {
+	return &PointerMatcher{
+		Matcher: matcher,
+	}
+}
+
+type PointerMatcher struct {
+	Matcher types.GomegaMatcher
+
+	// Failure message.
+	failure string
+}
+
+func (m *PointerMatcher) Match(actual interface{}) (bool, error) {
+	val := reflect.ValueOf(actual)
+
+	// return error if actual type is not a pointer
+	if val.Kind() != reflect.Ptr {
+		return false, fmt.Errorf("PointerMatcher expects a pointer but we have '%s'", val.Kind())
+	}
+
+	if !val.IsValid() || val.IsNil() {
+		m.failure = format.Message(actual, "not to be <nil>")
+		return false, nil
+	}
+
+	// Forward the value.
+	elem := val.Elem().Interface()
+	match, err := m.Matcher.Match(elem)
+	if !match {
+		m.failure = m.Matcher.FailureMessage(elem)
+	}
+	return match, err
+}
+
+func (m *PointerMatcher) FailureMessage(_ interface{}) (message string) {
+	return m.failure
+}
+
+func (m *PointerMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return m.Matcher.NegatedFailureMessage(actual)
+}

--- a/vendor/github.com/onsi/gomega/gstruct/types.go
+++ b/vendor/github.com/onsi/gomega/gstruct/types.go
@@ -1,0 +1,15 @@
+package gstruct
+
+//Options is the type for options passed to some matchers.
+type Options int
+
+const (
+	//IgnoreExtras tells the matcher to ignore extra elements or fields, rather than triggering a failure.
+	IgnoreExtras Options = 1 << iota
+	//IgnoreMissing tells the matcher to ignore missing elements or fields, rather than triggering a failure.
+	IgnoreMissing
+	//AllowDuplicates tells the matcher to permit multiple members of the slice to produce the same ID when
+	//considered by the indentifier function. All members that map to a given key must still match successfully
+	//with the matcher that is provided for that key.
+	AllowDuplicates
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,7 +35,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 # github.com/gardener/external-dns-management v0.7.18
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
-# github.com/gardener/gardener v1.11.3
+# github.com/gardener/gardener v1.12.8
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE
@@ -62,6 +62,7 @@ github.com/gardener/gardener/pkg/client/core/clientset/versioned/typed/core/v1al
 github.com/gardener/gardener/pkg/client/core/clientset/versioned/typed/core/v1beta1
 github.com/gardener/gardener/pkg/client/extensions/clientset/versioned/scheme
 github.com/gardener/gardener/pkg/client/kubernetes
+github.com/gardener/gardener/pkg/client/kubernetes/utils
 github.com/gardener/gardener/pkg/extensions
 github.com/gardener/gardener/pkg/logger
 github.com/gardener/gardener/pkg/mock/go/context
@@ -231,6 +232,8 @@ github.com/onsi/ginkgo/types
 ## explicit
 github.com/onsi/gomega
 github.com/onsi/gomega/format
+github.com/onsi/gomega/gstruct
+github.com/onsi/gomega/gstruct/errors
 github.com/onsi/gomega/internal/assertion
 github.com/onsi/gomega/internal/asyncassertion
 github.com/onsi/gomega/internal/oraclematcher


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability robustness
/kind enhancement
/priority normal

**What this PR does / why we need it**:
Similar to gardener/gardener#2888, the `ManagedResource`'s `.status.conditions[].lastUpdateTime` is no longer continuously updated to prevent spamming etcd with too many unnecessary updates. 

**Special notes for your reviewer**:
As of today, there is no controller that would check if the GRM is down and set the conditions statuses to `Unknown` (contrary to what we do for `Shoot`s, for example). We could introduce it in the future, but it's not clear yet if we want that and how that would look like.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The `ManagedResource`'s `.status.conditions[].lastUpdateTime` is no longer continuously updated. This will greatly reduce the number of update calls to the kube-apiserver/etcd.
```
