### PR TITLE
Inject effective version into binary

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 **
 
 # Exclude folders relevant for build
+!.git
+!.dockerignore
 !api/
 !charts/
 !cmd/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM eu.gcr.io/gardener-project/3rd/golang:1.15.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-resource-manager
 COPY . .
-RUN make install
+
+ARG EFFECTIVE_VERSION
+RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 #############      gardener-resource-manager
 FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 AS gardener-resource-manager

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NAME                        := gardener-resource-manager
-IMAGE_REPOSITORY            := eu.gcr.io/gardener-project/gardener/$(NAME)
-REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-VERSION                     := $(shell cat "$(REPO_ROOT)/VERSION")
-LD_FLAGS                    := "-w -X github.com/gardener/$(NAME)/pkg/version.Version=$(VERSION)"
-VERIFY                      := true
+NAME              := gardener-resource-manager
+IMAGE_REPOSITORY  := eu.gcr.io/gardener-project/gardener/$(NAME)
+REPO_ROOT         := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+VERSION           := $(shell cat "$(REPO_ROOT)/VERSION")
+EFFECTIVE_VERSION := $(VERSION)-$(shell git rev-parse HEAD)
+
+ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
+	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
+endif
+LD_FLAGS := "-w $(shell EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/get-build-ld-flags.sh github.com/gardener/$(NAME) $(REPO_ROOT)/VERSION)"
 
 #########################################
 # Rules for local development scenarios #
@@ -41,7 +45,7 @@ start:
 
 .PHONY: install
 install:
-	@LD_FLAGS=$(LD_FLAGS) $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/install.sh ./...
+	@LD_FLAGS=$(LD_FLAGS) $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/install.sh ./cmd/...
 
 .PHONY: docker-login
 docker-login:
@@ -49,14 +53,13 @@ docker-login:
 
 .PHONY: docker-image
 docker-image:
-	@docker build --build-arg VERIFY=$(VERIFY) -t $(IMAGE_REPOSITORY):$(VERSION) -f Dockerfile --target gardener-resource-manager .
+	# building docker image with tag $(IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)
+	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_REPOSITORY):$(EFFECTIVE_VERSION) --rm --target gardener-resource-manager .
 
-.PHONY: all
-ifeq ($(VERIFY),true)
-all: verify generate install
-else
-all: generate install
-endif
+.PHONY: docker-push
+docker-push:
+	@if ! docker images $(IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(EFFECTIVE_VERSION); then echo "$(IMAGE_REPOSITORY) version $(EFFECTIVE_VERSION) is not yet built. Please run 'make docker-image'"; false; fi
+	@gcloud docker -- push $(IMAGE_REPOSITORY):$(EFFECTIVE_VERSION)
 
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -30,6 +30,7 @@ import (
 	secretcontroller "github.com/gardener/gardener-resource-manager/pkg/controller/secret"
 	"github.com/gardener/gardener-resource-manager/pkg/healthz"
 	logpkg "github.com/gardener/gardener-resource-manager/pkg/log"
+	"github.com/gardener/gardener-resource-manager/pkg/version"
 )
 
 var log = runtimelog.Log.WithName("gardener-resource-manager")
@@ -48,13 +49,14 @@ func NewResourceManagerCommand() *cobra.Command {
 	healthControllerOpts := &healthcontroller.ControllerOptions{}
 
 	cmd := &cobra.Command{
-		Use: "gardener-resource-manager",
+		Use:     "gardener-resource-manager",
+		Version: version.Get().GitVersion,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 
-			entryLog.Info("Starting gardener-resource-manager...")
+			entryLog.Info("Starting gardener-resource-manager...", "version", version.Get().GitVersion)
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				entryLog.Info(fmt.Sprintf("FLAG: --%s=%s", flag.Name, flag.Value))
 			})

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -14,5 +14,52 @@
 
 package version
 
-// Version is a string that is overwritten during build time using ld flags.
-var Version = "binary not built correctly"
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	apimachineryversion "k8s.io/apimachinery/pkg/version"
+)
+
+var (
+	gitVersion   = "v0.0.0-dev"
+	gitCommit    string
+	gitTreeState string
+	buildDate    = "1970-01-01T00:00:00Z"
+
+	version *apimachineryversion.Info
+)
+
+// Get returns the overall codebase version. It's for detecting
+// what code a binary was built from.
+// These variables typically come from -ldflags settings and in
+// their absence fallback to the settings in pkg/version/version.go
+func Get() apimachineryversion.Info {
+	return *version
+}
+
+func init() {
+	var (
+		versionParts = strings.Split(gitVersion, ".")
+		gitMajor     string
+		gitMinor     string
+	)
+
+	if len(versionParts) >= 2 {
+		gitMajor = strings.TrimPrefix(versionParts[0], "v")
+		gitMinor = versionParts[1]
+	}
+
+	version = &apimachineryversion.Info{
+		Major:        gitMajor,
+		Minor:        gitMinor,
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability dev-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:

With this PR the effective version is injected into the built binary, just like we do it in g/g (ref https://github.com/gardener/gardener/pull/2500) and images built by `make docker-image` are tagged with the effective version (including the commit hash) just like in the pipeline.
Also, a make target `docker-push` was added.

All of this makes it easier to built and push development images for verification of new changes.

Additionally, grm has a `--version` option now and logs the binary version on startup:
```
$ docker run eu.gcr.io/gardener-project/gardener/gardener-resource-manager:v0.21.0-dev-ae4644d6785a17caa92dc2c99ef197f1ecea5fd9 --version
gardener-resource-manager version v0.21.0-dev-ae4644d6785a17caa92dc2c99ef197f1ecea5fd9

$ docker run eu.gcr.io/gardener-project/gardener/gardener-resource-manager:v0.21.0-dev-ae4644d6785a17caa92dc2c99ef197f1ecea5fd9
{"level":"info","ts":"2020-12-03T08:48:21.917Z","logger":"gardener-resource-manager.entrypoint","msg":"Starting gardener-resource-manager...","version":"v0.21.0-dev-ae4644d6785a17caa92dc2c99ef197f1ecea5fd9"}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```feature developer
Docker images built by `make docker-images` are now tagged and build with the commit hash appended to the version.
```
```feature operator
gardener-resource-manager now logs its own version on startup or when executed with `--version`.
```
