### PR TITLE
Improve accuracy of CheckDaemonSet function

### DIFF
--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -119,11 +119,22 @@ func CheckDaemonSet(daemonSet *appsv1.DaemonSet) error {
 		return fmt.Errorf("observed generation outdated (%d/%d)", daemonSet.Status.ObservedGeneration, daemonSet.Generation)
 	}
 
-	maxUnavailable := daemonSetMaxUnavailable(daemonSet)
-
-	if requiredAvailable := daemonSet.Status.DesiredNumberScheduled - maxUnavailable; daemonSet.Status.CurrentNumberScheduled < requiredAvailable {
-		return fmt.Errorf("not enough available replicas (%d/%d)", daemonSet.Status.CurrentNumberScheduled, requiredAvailable)
+	if daemonSet.Status.CurrentNumberScheduled < daemonSet.Status.DesiredNumberScheduled {
+		return fmt.Errorf("not enough scheduled pods (%d/%d)", daemonSet.Status.CurrentNumberScheduled, daemonSet.Status.DesiredNumberScheduled)
 	}
+
+	if daemonSet.Status.NumberMisscheduled > 0 {
+		return fmt.Errorf("misscheduled pods found (%d)", daemonSet.Status.NumberMisscheduled)
+	}
+
+	if maxUnavailable := daemonSetMaxUnavailable(daemonSet); daemonSet.Status.NumberUnavailable > maxUnavailable {
+		return fmt.Errorf("too many unavailable pods found (%d/%d, only max. %d unavailable pods allowed)", daemonSet.Status.NumberUnavailable, daemonSet.Status.CurrentNumberScheduled, maxUnavailable)
+	}
+
+	if daemonSet.Status.NumberReady < daemonSet.Status.DesiredNumberScheduled {
+		return fmt.Errorf("unready pods found (%d/%d), %d pods updated", daemonSet.Status.NumberReady, daemonSet.Status.DesiredNumberScheduled, daemonSet.Status.UpdatedNumberScheduled)
+	}
+
 	return nil
 }
 

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -94,13 +94,22 @@ var _ = Describe("health", func() {
 
 	Context("CheckDaemonSet", func() {
 		oneUnavailable := intstr.FromInt(1)
+
 		DescribeTable("daemonsets",
 			func(daemonSet *appsv1.DaemonSet, matcher types.GomegaMatcher) {
 				err := health.CheckDaemonSet(daemonSet)
 				Expect(err).To(matcher)
 			},
-			Entry("healthy", &appsv1.DaemonSet{}, BeNil()),
-			Entry("healthy with one unavailable", &appsv1.DaemonSet{
+			Entry("not observed at latest version", &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			}, HaveOccurred()),
+			Entry("not enough scheduled", &appsv1.DaemonSet{
+				Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 1},
+			}, HaveOccurred()),
+			Entry("misscheduled pods", &appsv1.DaemonSet{
+				Status: appsv1.DaemonSetStatus{NumberMisscheduled: 1},
+			}, HaveOccurred()),
+			Entry("too many unavailable pods", &appsv1.DaemonSet{
 				Spec: appsv1.DaemonSetSpec{UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 					Type: appsv1.RollingUpdateDaemonSetStrategyType,
 					RollingUpdate: &appsv1.RollingUpdateDaemonSet{
@@ -109,15 +118,24 @@ var _ = Describe("health", func() {
 				}},
 				Status: appsv1.DaemonSetStatus{
 					DesiredNumberScheduled: 2,
+					CurrentNumberScheduled: 2,
+					NumberUnavailable:      2,
+					NumberReady:            0,
+				},
+			}, HaveOccurred()),
+			Entry("too less ready pods", &appsv1.DaemonSet{
+				Status: appsv1.DaemonSetStatus{
+					DesiredNumberScheduled: 1,
 					CurrentNumberScheduled: 1,
 				},
+			}, HaveOccurred()),
+			Entry("healthy", &appsv1.DaemonSet{
+				Status: appsv1.DaemonSetStatus{
+					DesiredNumberScheduled: 1,
+					CurrentNumberScheduled: 1,
+					NumberReady:            1,
+				},
 			}, BeNil()),
-			Entry("not observed at latest version", &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{Generation: 1},
-			}, HaveOccurred()),
-			Entry("not enough updated scheduled", &appsv1.DaemonSet{
-				Status: appsv1.DaemonSetStatus{DesiredNumberScheduled: 1},
-			}, HaveOccurred()),
 		)
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR improves the `CheckDaemonSet` function to detect more erroneous situations (such as described in #84, for example).

**Which issue(s) this PR fixes**:
Fixes #84

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The `CheckDaemonSet` function does now lead to more accurate results.
```
