### PR TITLE
accept existing loadbalancerIP

### DIFF
--- a/pkg/controller/managedresource/merger.go
+++ b/pkg/controller/managedresource/merger.go
@@ -245,6 +245,7 @@ func mergeService(scheme *runtime.Scheme, oldObj, newObj runtime.Object) error {
 
 	switch newService.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeNodePort:
+		// do not override ports
 		var ports []corev1.ServicePort
 
 		for _, np := range newService.Spec.Ports {
@@ -259,6 +260,11 @@ func mergeService(scheme *runtime.Scheme, oldObj, newObj runtime.Object) error {
 			ports = append(ports, p)
 		}
 		newService.Spec.Ports = ports
+
+		// do not override loadbalancer IP
+		if newService.Spec.LoadBalancerIP == "" && oldService.Spec.LoadBalancerIP != "" {
+			newService.Spec.LoadBalancerIP = oldService.Spec.LoadBalancerIP
+		}
 
 	case corev1.ServiceTypeExternalName:
 		// there is no ClusterIP in this case

--- a/pkg/controller/managedresource/merger_test.go
+++ b/pkg/controller/managedresource/merger_test.go
@@ -795,6 +795,11 @@ var _ = Describe("merger", func() {
 
 				expected = old.DeepCopy()
 			}),
+			Entry("LoadBalancer should retain spec.loadBalancerIP", func() {
+				old.Spec.LoadBalancerIP = "1.2.3.4"
+
+				expected = old.DeepCopy()
+			}),
 		)
 
 		DescribeTable("ExternalName to", func(mutator func()) {


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/priority normal

**What this PR does / why we need it**:

Does not override an existing Service of `type=LoadBalancer`'s load balancer IP

**Which issue(s) this PR fixes**:
Fixes #107 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `.spec.loadBalancerIP` value for `Service`s is now preserved.
```
