### PR TITLE
Fix discovery rate limits

### DIFF
--- a/cmd/gardener-resource-manager/main.go
+++ b/cmd/gardener-resource-manager/main.go
@@ -17,6 +17,8 @@ package main
 import (
 	"os"
 
+	"k8s.io/client-go/rest"
+
 	"github.com/gardener/gardener-resource-manager/cmd/gardener-resource-manager/app"
 	"github.com/gardener/gardener-resource-manager/pkg/log"
 
@@ -25,6 +27,13 @@ import (
 )
 
 func main() {
+	rest.SetDefaultWarningHandler(
+		rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{
+			// only print a given warning the first time we receive it
+			Deduplicate: true,
+		}),
+	)
+
 	runtimelog.SetLogger(log.ZapLogger(false))
 	ctx := signals.SetupSignalHandler()
 

--- a/pkg/cmd/source.go
+++ b/pkg/cmd/source.go
@@ -19,10 +19,10 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -90,7 +90,7 @@ func (o *SourceClientOptions) Completed() *SourceClientConfig {
 
 func getSourceScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(kubernetesscheme.AddToScheme(scheme))
 	utilruntime.Must(resourcesv1alpha1.AddToScheme(scheme))
 	return scheme
 }

--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -79,6 +79,10 @@ func (o *TargetClientOptions) Complete() error {
 		return fmt.Errorf("unable to create REST config for target cluster: %w", err)
 	}
 
+	// TODO: make this configurable
+	restConfig.QPS = 100.0
+	restConfig.Burst = 130
+
 	restMapper, err := getTargetRESTMapper(restConfig)
 	if err != nil {
 		return fmt.Errorf("unable to create REST mapper for target cluster: %w", err)
@@ -90,10 +94,6 @@ func (o *TargetClientOptions) Complete() error {
 		targetCache  cache.Cache
 		targetClient client.Client
 	)
-
-	// TODO: make this configurable
-	restConfig.QPS = 100.0
-	restConfig.Burst = 130
 
 	if o.disableCache {
 		// create direct client for target cluster
@@ -157,7 +157,7 @@ func getTargetRESTMapper(config *rest.Config) (meta.RESTMapper, error) {
 	return apiutil.NewDynamicRESTMapper(
 		config,
 		apiutil.WithLazyDiscovery,
-		apiutil.WithLimiter(rate.NewLimiter(rate.Every(10*time.Second), 1)), // rediscover at maximum every 10s
+		apiutil.WithLimiter(rate.NewLimiter(rate.Every(1*time.Minute), 1)), // rediscover at maximum every minute
 	)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/priority normal

**What this PR does / why we need it**:

Follow-up on #111.

We observed many throttled discovery calls (see #109), because the target REST mapper was rediscovering resources with a rate of `1 / 10s`, but the default QPS/burst settings of `5 / 100` were used in the discovery client.
For grm's targeting shoot clusters, grm tries to do a rediscovery in every reconciliation loop because it checks if any HVPA resources are present, that scale resources applied by grm.

This becomes a problem in conjunction with unavailable `APIServices` (the discovery client will run into the default timeout of `32s`) and the reconciliation timeouts added in #102. I.e. if there are unavailable `APIServices` the throttled discovery call will take long enough to exceed the reconciliations timeout, giving the actual reconciliation no chance to do its work.

Additionally this PR:
- adds the entire k8s scheme to the source client instead of only the `core` scheme
- deduplicates client-side warnings about deprecated API versions

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-resource-manager/issues/109

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A problem with long running ManagedResource reconciliations caused by unavailable `APIServices` was fixed.
```
