### PR TITLE
[release-v0.21] Cherry-pick of #108: accept existing loadbalancerIP

### DIFF
--- a/pkg/controller/managedresource/merger.go
+++ b/pkg/controller/managedresource/merger.go
@@ -245,6 +245,7 @@ func mergeService(scheme *runtime.Scheme, oldObj, newObj runtime.Object) error {
 
 	switch newService.Spec.Type {
 	case corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeNodePort:
+		// do not override ports
 		var ports []corev1.ServicePort
 
 		for _, np := range newService.Spec.Ports {
@@ -259,6 +260,11 @@ func mergeService(scheme *runtime.Scheme, oldObj, newObj runtime.Object) error {
 			ports = append(ports, p)
 		}
 		newService.Spec.Ports = ports
+
+		// do not override loadbalancer IP
+		if newService.Spec.LoadBalancerIP == "" && oldService.Spec.LoadBalancerIP != "" {
+			newService.Spec.LoadBalancerIP = oldService.Spec.LoadBalancerIP
+		}
 
 	case corev1.ServiceTypeExternalName:
 		// there is no ClusterIP in this case

--- a/pkg/controller/managedresource/merger_test.go
+++ b/pkg/controller/managedresource/merger_test.go
@@ -795,6 +795,11 @@ var _ = Describe("merger", func() {
 
 				expected = old.DeepCopy()
 			}),
+			Entry("LoadBalancer should retain spec.loadBalancerIP", func() {
+				old.Spec.LoadBalancerIP = "1.2.3.4"
+
+				expected = old.DeepCopy()
+			}),
 		)
 
 		DescribeTable("ExternalName to", func(mutator func()) {


### PR DESCRIPTION
Cherry-pick of #108 to `release-v0.21`.

```bugfix operator
The `.spec.loadBalancerIP` value for `Service`s is now preserved.
```