### PR TITLE
[release-v0.21] Cherry-pick of #112: Fix discovery rate limits

### DIFF
--- a/pkg/cmd/source.go
+++ b/pkg/cmd/source.go
@@ -19,10 +19,10 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -90,7 +90,7 @@ func (o *SourceClientOptions) Completed() *SourceClientConfig {
 
 func getSourceScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
-	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(kubernetesscheme.AddToScheme(scheme))
 	utilruntime.Must(resourcesv1alpha1.AddToScheme(scheme))
 	return scheme
 }

--- a/pkg/cmd/target.go
+++ b/pkg/cmd/target.go
@@ -73,6 +73,10 @@ func (o *TargetClientOptions) Complete() error {
 		return fmt.Errorf("unable to create REST config for target cluster: %w", err)
 	}
 
+	// TODO: make this configurable
+	restConfig.QPS = 100.0
+	restConfig.Burst = 130
+
 	restMapper, err := getTargetRESTMapper(restConfig)
 	if err != nil {
 		return fmt.Errorf("unable to create REST mapper for target cluster: %w", err)
@@ -146,7 +150,7 @@ func getTargetRESTMapper(config *rest.Config) (meta.RESTMapper, error) {
 	return apiutil.NewDynamicRESTMapper(
 		config,
 		apiutil.WithLazyDiscovery,
-		apiutil.WithLimiter(rate.NewLimiter(rate.Every(10*time.Second), 1)), // rediscover at maximum every 10s
+		apiutil.WithLimiter(rate.NewLimiter(rate.Every(1*time.Minute), 1)), // rediscover at maximum every minute
 	)
 }
 
@@ -169,9 +173,6 @@ func getTargetRESTConfig(kubeconfigPath string) (*rest.Config, error) {
 }
 
 func newCachedClient(cache cache.Cache, config rest.Config, options client.Options) (client.Client, error) {
-	config.QPS = 100.0
-	config.Burst = 130
-
 	// Create the Client for Write operations.
 	c, err := client.New(&config, options)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick of #112 to `release-v0.21`.

```bugfix operator
A problem with long running ManagedResource reconciliations caused by unavailable `APIServices` was fixed.
```