### PR TITLE
Introduce ignore mode for resources

### DIFF
--- a/api/resources/v1alpha1/types.go
+++ b/api/resources/v1alpha1/types.go
@@ -30,6 +30,13 @@ const (
 	// true then the controller will not delete the object in case it is removed from the ManagedResource or the
 	// ManagedResource itself is deleted.
 	KeepObject = "resources.gardener.cloud/keep-object"
+	// Mode is a constant for an annotation on a resource managed by a ManagedResource. It indicates the
+	// mode that should be used to reconcile the resource.
+	Mode = "resources.gardener.cloud/mode"
+	// ModeIgnore is a constant for the value of the mode annotation describing an ignore mode.
+	// Reconciliation in ignore more removes the resource from the ManagedResource status and does not
+	// perform any action on the cluster.
+	ModeIgnore = "Ignore"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -146,8 +153,11 @@ const (
 	// because deleting the resources failed.
 	ConditionDeletionFailed = "DeletionFailed"
 	// ConditionDeletionPending indicates that the `ResourcesApplied` condition is `Progressing`,
-	// because the deletion of some resources are still pending.
+	// because the deletion of some resources is still pending.
 	ConditionDeletionPending = "DeletionPending"
+	// ReleaseOfOrphanedResourcesFailed indicates that the `ResourcesApplied` condition is `False`,
+	// because the release of orphaned resources failed.
+	ReleaseOfOrphanedResourcesFailed = "ReleaseOfOrphanedResourcesFailed"
 	// ConditionHealthChecksPending indicates that the `ResourcesHealthy` condition is `Unknown`,
 	// because the health checks have not been completely executed yet for the current set of resources.
 	ConditionHealthChecksPending = "HealthChecksPending"

--- a/docs/concepts/managed-resource.md
+++ b/docs/concepts/managed-resource.md
@@ -1,5 +1,14 @@
 # Managed Resource
 
+### Modes
+
+The gardener-resource-manager can manage a resource in different modes. The supported modes are:
+- `Ignore`
+  - The corresponding resource is removed from the ManagedResource status (`.status.resources`). No action is performed on the cluster - the resource is no longer "managed" (updated or deleted).
+  - The primary use case is a migration of a resource from one ManagedResource to another one.
+
+The mode for a resource can be specified with the `resources.gardener.cloud/mode` annotation. The annotation should be specified in the encoded resource manifest in the Secret that is referenced by the ManagedResource.
+
 ### Resource Class
 
 By default gardener-resource-manager controller watches for ManagedResources in all namespaces. `--namespace` flag can be specified to gardener-resource-manager binary to restrict the watch to ManagedResources in a single namespace.
@@ -49,13 +58,13 @@ The following section describes a healthy ManagedResource:
 ]  
 ```
 
-## Ignoring Updates 
+### Ignoring Updates 
 
 In some cases it is not desirable to update or re-apply some of the cluster components (for example, if customization is required or needs to be applied by the end-user). 
 For these resources, the annotation "resources.gardener.cloud/ignore" needs to be set to "true" or a truthy value (Truthy values are "1", "t", "T", "true", "TRUE", "True") in the corresponding managed resource secrets, 
 this can be done from the components that create the managed resource secrets, for example Gardener extensions or Gardener. Once this is done, the resource will be initially created and later ignored during reconciliation.
 
-## Origin
+### Origin
 
 All the objects managed by the resource manager get a dedicated annotation 
 `resources.gardener.cloud/origin` describing the `ManagedResource` object that describes 

--- a/vendor/github.com/gardener/gardener-resource-manager/api/resources/v1alpha1/types.go
+++ b/vendor/github.com/gardener/gardener-resource-manager/api/resources/v1alpha1/types.go
@@ -30,6 +30,13 @@ const (
 	// true then the controller will not delete the object in case it is removed from the ManagedResource or the
 	// ManagedResource itself is deleted.
 	KeepObject = "resources.gardener.cloud/keep-object"
+	// Mode is a constant for an annotation on a resource managed by a ManagedResource. It indicates the
+	// mode that should be used to reconcile the resource.
+	Mode = "resources.gardener.cloud/mode"
+	// ModeIgnore is a constant for the value of the mode annotation describing an ignore mode.
+	// Reconciliation in ignore more removes the resource from the ManagedResource status and does not
+	// perform any action on the cluster.
+	ModeIgnore = "Ignore"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -146,8 +153,11 @@ const (
 	// because deleting the resources failed.
 	ConditionDeletionFailed = "DeletionFailed"
 	// ConditionDeletionPending indicates that the `ResourcesApplied` condition is `Progressing`,
-	// because the deletion of some resources are still pending.
+	// because the deletion of some resources is still pending.
 	ConditionDeletionPending = "DeletionPending"
+	// ReleaseOfOrphanedResourcesFailed indicates that the `ResourcesApplied` condition is `False`,
+	// because the release of orphaned resources failed.
+	ReleaseOfOrphanedResourcesFailed = "ReleaseOfOrphanedResourcesFailed"
 	// ConditionHealthChecksPending indicates that the `ResourcesHealthy` condition is `Unknown`,
 	// because the health checks have not been completely executed yet for the current set of resources.
 	ConditionHealthChecksPending = "HealthChecksPending"


### PR DESCRIPTION
/kind enhancement

This PR implements the Ignore mode as it is described in https://github.com/gardener/gardener-resource-manager/issues/82. As stated in the issue, the primary use case for this mode is a migration of resource from one ManagedResource to another one.

Part of https://github.com/gardener/gardener-resource-manager/issues/82
Required for https://github.com/gardener/gardener/issues/2227

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
gardener-resource-manager now supports a `Ignore` mode for resources managed by a ManagedResource. The primary use case for this mode is a migration of resource from one ManagedResource to another one.
```
