### PR TITLE
Switch leader election to leases

### DIFF
--- a/charts/gardener-resource-manager/values.yaml
+++ b/charts/gardener-resource-manager/values.yaml
@@ -20,7 +20,7 @@ controllers:
 
 leaderElection:
   enabled: true
-  resourceLock: configmapsleases
+  resourceLock: leases
   leaseDuration: 15s
   renewDeadline: 10s
   retryPeriod: 2s

--- a/pkg/cmd/manager.go
+++ b/pkg/cmd/manager.go
@@ -56,13 +56,8 @@ type ManagerConfig struct {
 
 // AddFlags adds the needed command line flags to the given FlagSet.
 func (o *ManagerOptions) AddFlags(fs *pflag.FlagSet) {
-	// TODO: migrate default to `leases` in one of the next releases
-	// `configmapsleases` has been default since v0.22 (but was not configurable via flags)
-	// maybe consider changing the default in v0.24?
-	defaultLeaderElectionResourceLock := resourcelock.ConfigMapsLeasesResourceLock
-
 	fs.BoolVar(&o.leaderElection, "leader-election", true, "enable or disable leader election")
-	fs.StringVar(&o.leaderElectionResourceLock, "leader-election-resource-lock", defaultLeaderElectionResourceLock, "Which resource type to use for leader election. "+
+	fs.StringVar(&o.leaderElectionResourceLock, "leader-election-resource-lock", resourcelock.LeasesResourceLock, "Which resource type to use for leader election. "+
 		"Supported options are 'endpoints', 'configmaps', 'leases', 'endpointsleases' and 'configmapsleases'.")
 	fs.StringVar(&o.leaderElectionNamespace, "leader-election-namespace", "", "namespace for leader election")
 	fs.DurationVar(&o.leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second, "lease duration for leader election")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:

Switch leader election to leases.

`configmapsleases` has been the default since [`g/grm@v0.22.0`](https://github.com/gardener/gardener-resource-manager/releases/tag/v0.22.0) (used in [g/g since `v1.18.0`](https://github.com/gardener/gardener/commit/00ed3a4283b8b2469c054972e160f89aec409e42)), so I think it's safe to migrate to `leases` in `g/grm@v0.24.0`, even without any special migration logic.

**Which issue(s) this PR fixes**:
Fixes #77

**Special notes for your reviewer**:

- this will not remove the old leader election configmaps, so they will be orphaned
- once this is merged we can finally get rid of the [lowered leader election frequency in g/g](https://github.com/gardener/gardener/blob/666245078f8bd6538d623dcc2784ba2296610052/pkg/operation/botanist/resource_manager.go#L51-L58) introduced by https://github.com/gardener/gardener/pull/2667

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The default leader election resource lock of `gardener-resource-manager` has been changed from `configmapsleases` to `leases`.
Please make sure, that you had at least `gardener-resource-manager@v0.22` running before upgrading to `v0.24`, so that it has successfully required leadership with the hybrid resource lock (`configmapsleases`) at least once.
```
