### PR TITLE
Use resources.gardener.cloud in annotations

### DIFF
--- a/api/resources/v1alpha1/types.go
+++ b/api/resources/v1alpha1/types.go
@@ -39,11 +39,11 @@ const (
 	ModeIgnore = "Ignore"
 	// PreserveReplicas is a constant for an annotation on a resource managed by a ManagedResource. If set to
 	// true then the controller will keep the `spec.replicas` field's value during updates to the resource.
-	PreserveReplicas = "gardener-resource-manager.gardener.cloud/preserve-replicas"
+	PreserveReplicas = "resources.gardener.cloud/preserve-replicas"
 	// PreserveResources is a constant for an annotation on a resource managed by a ManagedResource. If set to
 	// true then the controller will keep the resource requests and limits in Pod templates (e.g. in a
 	// DeploymentSpec) during updates to the resource.
-	PreserveResources = "gardener-resource-manager.gardener.cloud/preserve-resources"
+	PreserveResources = "resources.gardener.cloud/preserve-resources"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/managedresource/merger_test.go
+++ b/pkg/controller/managedresource/merger_test.go
@@ -382,7 +382,7 @@ var _ = Describe("merger", func() {
 
 		It("should not overwrite old .spec.replicas if preserve-replicas is true", func() {
 			new.Spec.Replicas = pointer.Int32Ptr(2)
-			new.ObjectMeta.Annotations["gardener-resource-manager.gardener.cloud/preserve-replicas"] = "true"
+			new.ObjectMeta.Annotations["resources.gardener.cloud/preserve-replicas"] = "true"
 
 			Expect(s.Convert(old, current, nil)).Should(Succeed())
 			Expect(s.Convert(new, desired, nil)).Should(Succeed())
@@ -428,7 +428,7 @@ var _ = Describe("merger", func() {
 				},
 			}
 
-			new.ObjectMeta.Annotations["gardener-resource-manager.gardener.cloud/preserve-resources"] = "true"
+			new.ObjectMeta.Annotations["resources.gardener.cloud/preserve-resources"] = "true"
 
 			Expect(s.Convert(old, current, nil)).Should(Succeed())
 			Expect(s.Convert(new, desired, nil)).Should(Succeed())

--- a/vendor/github.com/gardener/gardener-resource-manager/api/resources/v1alpha1/types.go
+++ b/vendor/github.com/gardener/gardener-resource-manager/api/resources/v1alpha1/types.go
@@ -39,11 +39,11 @@ const (
 	ModeIgnore = "Ignore"
 	// PreserveReplicas is a constant for an annotation on a resource managed by a ManagedResource. If set to
 	// true then the controller will keep the `spec.replicas` field's value during updates to the resource.
-	PreserveReplicas = "gardener-resource-manager.gardener.cloud/preserve-replicas"
+	PreserveReplicas = "resources.gardener.cloud/preserve-replicas"
 	// PreserveResources is a constant for an annotation on a resource managed by a ManagedResource. If set to
 	// true then the controller will keep the resource requests and limits in Pod templates (e.g. in a
 	// DeploymentSpec) during updates to the resource.
-	PreserveResources = "gardener-resource-manager.gardener.cloud/preserve-resources"
+	PreserveResources = "resources.gardener.cloud/preserve-resources"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
The annotation keys should use the same API group as the other annotations and the CRDs.
Missed that during the review of https://github.com/gardener/gardener-resource-manager/pull/122.

cc @harishmanasa 
